### PR TITLE
[RPRBLND-1224] Viewport Shading panel in Rendered mode

### DIFF
--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -153,10 +153,12 @@ class ShadingData:
 
         self.type = shading.type
         if self.type == 'RENDERED':
-            return
+            self.use_scene_lights = shading.use_scene_lights_render
+            self.use_scene_world = shading.use_scene_world_render
+        else:
+            self.use_scene_lights = shading.use_scene_lights
+            self.use_scene_world = shading.use_scene_world
 
-        self.use_scene_lights = shading.use_scene_lights
-        self.use_scene_world = shading.use_scene_world
         if not self.use_scene_world:
             self.studio_light = shading.selected_studio_light.path
             if not self.studio_light:

--- a/src/rprblender/ui/__init__.py
+++ b/src/rprblender/ui/__init__.py
@@ -179,6 +179,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     view3d.RPR_VIEW3D_MT_menu,
     view3d.RPR_VIEW3D_PT_panel,
     view3d.RPR_VIEW3D_PT_shading_lighting,
+    view3d.RPR_VIEW3D_PT_shading_render_pass,
 
     mesh.RPR_DATA_PT_mesh,
 ])

--- a/src/rprblender/ui/__init__.py
+++ b/src/rprblender/ui/__init__.py
@@ -178,8 +178,10 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
 
     view3d.RPR_VIEW3D_MT_menu,
     view3d.RPR_VIEW3D_PT_panel,
+    view3d.RPR_VIEW3D_PT_shading_lighting,
 
-    mesh.RPR_DATA_PT_mesh,])
+    mesh.RPR_DATA_PT_mesh,
+])
 
 
 def register():

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -373,3 +373,4 @@ class RPR_RENDER_PT_debug(RPR_Panel):
         row.enabled = rpr.trace_dump
         row.use_property_split = False
         row.prop(rpr, 'trace_dump_folder', text="")
+

--- a/src/rprblender/ui/view3d.py
+++ b/src/rprblender/ui/view3d.py
@@ -48,3 +48,42 @@ def draw_menu(self, context):
     if context.engine == 'RPR':
         layout = self.layout
         layout.popover('RPR_VIEW3D_PT_panel')
+
+class RPR_VIEW3D_PT_shading_lighting(RPR_Panel):
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'HEADER'
+    bl_label = "Lighting"
+    bl_parent_id = 'VIEW3D_PT_shading'
+
+    @classmethod
+    def poll(cls, context):
+        return (context.engine in cls.COMPAT_ENGINES
+            and context.space_data.shading.type == 'RENDERED')
+
+    def draw(self, context):
+        layout = self.layout
+        col = layout.column()
+        split = col.split(factor=0.9)
+
+        shading = context.space_data.shading
+        col.prop(shading, "use_scene_lights_render")
+        col.prop(shading, "use_scene_world_render")
+
+        if not shading.use_scene_world_render:
+            col = layout.column()
+            split = col.split(factor=0.9)
+
+            col = split.column()
+            sub = col.row()
+            sub.scale_y = 0.6
+            sub.template_icon_view(shading, "studio_light", scale_popup=3)
+
+            col = split.column()
+            col.operator("preferences.studiolight_show", emboss=False, text="", icon='PREFERENCES')
+
+            split = layout.split(factor=0.9)
+            col = split.column()
+            col.prop(shading, "studiolight_rotate_z", text="Rotation")
+            col.prop(shading, "studiolight_intensity")
+            col.prop(shading, "studiolight_background_alpha")
+

--- a/src/rprblender/ui/view3d.py
+++ b/src/rprblender/ui/view3d.py
@@ -49,6 +49,7 @@ def draw_menu(self, context):
         layout = self.layout
         layout.popover('RPR_VIEW3D_PT_panel')
 
+
 class RPR_VIEW3D_PT_shading_lighting(RPR_Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'HEADER'
@@ -87,3 +88,20 @@ class RPR_VIEW3D_PT_shading_lighting(RPR_Panel):
             col.prop(shading, "studiolight_intensity")
             col.prop(shading, "studiolight_background_alpha")
 
+
+class RPR_VIEW3D_PT_shading_render_pass(RPR_Panel):
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'HEADER'
+    bl_label = "Render Pass"
+    bl_parent_id = 'VIEW3D_PT_shading'
+
+    @classmethod
+    def poll(cls, context):
+        return (context.engine in cls.COMPAT_ENGINES
+            and context.space_data.shading.type == 'RENDERED')
+
+    def draw(self, context):
+        self.layout.use_property_split = True
+        self.layout.use_property_decorate = False
+
+        self.layout.prop(context.scene.rpr, 'render_mode', text='')


### PR DESCRIPTION
PURPOSE
In Cycles the viewport Shading panel is present in Rendered mode as well as in Material Preview mode.
Support similar panel for RPR in Rendered mode.

EFFECT OF CHANGE
- Added Shading options panel to the Rendered Viewport mode;

TECHNICAL STEPS
- added RPR panels for Shading and Render Path options in Rendered mode;
- allowed lightning overrides usage in Rendered Viewport mode.