### PR TITLE
RPRBLND-1338: Back plates does not work correctly 

### DIFF
--- a/src/bindings/pyrpr/src/pyrpr.py
+++ b/src/bindings/pyrpr/src/pyrpr.py
@@ -467,7 +467,6 @@ class Scene(Object):
         self.subdivision_camera = None
         self.objects = set()
 
-
     def set_camera(self, camera):
         self.camera = camera
         SceneSetCamera(self, self.camera)
@@ -487,6 +486,10 @@ class Scene(Object):
     def set_background_image(self, image):
         self.background_image = image
         SceneSetBackgroundImage(self, image)
+
+    def set_background_color(self, r, g, b):
+        self.set_background_image(
+            ImageData(self.context, np.full((2, 2, 4), (r, g, b, 1.0), dtype=np.float32)))
 
     def add_environment_override(self, core_id, light):
         self.environment_overrides[core_id] = light

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -185,9 +185,7 @@ class RenderEngine(Engine):
 
             # export backplate section for tile if backplate present
             if self.world_backplate:
-                self.world_backplate.export_tile(self.rpr_context,
-                                                 tile[0][0], tile[0][1],
-                                                 tile[0][0] + tile[1][0], tile[0][1] + tile[1][1])
+                self.world_backplate.export(self.rpr_context, tile)
 
             sample = 0
             if is_adaptive:
@@ -409,7 +407,7 @@ class RenderEngine(Engine):
         if scene.world.rpr.background_image_type == "BACKPLATE":
             # Different Backplate regions should be exported for each render tile
             self.world_backplate = world.Backplate(scene.world.rpr, (self.width, self.height))
-            self.world_backplate.export_full(self.rpr_context)
+            self.world_backplate.export(self.rpr_context)
 
         # SYNC MOTION BLUR
         self.rpr_context.do_motion_blur = scene.render.use_motion_blur and \

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -404,10 +404,10 @@ class RenderEngine(Engine):
 
         # Environment is synced once per frame
         world.sync(self.rpr_context, scene.world)
-        # if scene.world.rpr.background_image_type == "BACKPLATE":
-        #     # Different Backplate regions should be exported for each render tile
-        #     self.world_backplate = world.Backplate(scene.world.rpr, (self.width, self.height))
-        #     self.world_backplate.export(self.rpr_context)
+        if scene.world.rpr.background_image_type == "BACKPLATE":
+            # Different Backplate regions should be exported for each render tile
+            self.world_backplate = world.Backplate(scene.world.rpr, (self.width, self.height))
+            self.world_backplate.export(self.rpr_context)
 
         # SYNC MOTION BLUR
         self.rpr_context.do_motion_blur = scene.render.use_motion_blur and \

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -404,10 +404,10 @@ class RenderEngine(Engine):
 
         # Environment is synced once per frame
         world.sync(self.rpr_context, scene.world)
-        if scene.world.rpr.background_image_type == "BACKPLATE":
-            # Different Backplate regions should be exported for each render tile
-            self.world_backplate = world.Backplate(scene.world.rpr, (self.width, self.height))
-            self.world_backplate.export(self.rpr_context)
+        # if scene.world.rpr.background_image_type == "BACKPLATE":
+        #     # Different Backplate regions should be exported for each render tile
+        #     self.world_backplate = world.Backplate(scene.world.rpr, (self.width, self.height))
+        #     self.world_backplate.export(self.rpr_context)
 
         # SYNC MOTION BLUR
         self.rpr_context.do_motion_blur = scene.render.use_motion_blur and \

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -185,7 +185,7 @@ class RenderEngine(Engine):
 
             # export backplate section for tile if backplate present
             if self.world_backplate:
-                self.world_backplate.export(self.rpr_context, tile)
+                self.world_backplate.export(self.rpr_context, (self.width, self.height), tile)
 
             sample = 0
             if is_adaptive:
@@ -403,11 +403,8 @@ class RenderEngine(Engine):
             self.camera_data.export(rpr_camera)
 
         # Environment is synced once per frame
-        world.sync(self.rpr_context, scene.world)
-        if scene.world.rpr.background_image_type == "BACKPLATE":
-            # Different Backplate regions should be exported for each render tile
-            self.world_backplate = world.Backplate(scene.world.rpr, (self.width, self.height))
-            self.world_backplate.export(self.rpr_context)
+        world_settings = world.sync(self.rpr_context, scene.world)
+        self.world_backplate = world_settings.backplate
 
         # SYNC MOTION BLUR
         self.rpr_context.do_motion_blur = scene.render.use_motion_blur and \

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -660,6 +660,9 @@ class ViewportEngine(Engine):
                         image_filter_settings['resolution'] = resolution
                         self.setup_image_filter(image_filter_settings)
 
+                    if self.world_settings.backplate:
+                        self.world_settings.backplate.export(self.rpr_context, resolution)
+
                     self.is_resized = True
 
                 self.restart_render_event.set()

--- a/src/rprblender/export/image.py
+++ b/src/rprblender/export/image.py
@@ -104,8 +104,7 @@ class ImagePixels:
             data = np.fromiter(pixels, dtype=np.float32,
                                count=image.size[0] * image.size[1] * image.channels)
 
-        data = np.flipud(data.reshape(image.size[1], image.size[0], image.channels))
-        self.pixels = np.ascontiguousarray(data)
+        self.pixels = data.reshape(image.size[1], image.size[0], image.channels)
 
         self.name = image.name
         self.color_space = image.colorspace_settings.name
@@ -136,7 +135,7 @@ class ImagePixels:
                           y1 + (y2 - y1) * (tile[0][1] + tile[1][1]))
 
         pixels = self.pixels[int(y1): int(y2), int(x1):int(x2), :]
-        rpr_image = rpr_context.create_image_data(None, np.ascontiguousarray(pixels))
+        rpr_image = rpr_context.create_image_data(None, np.ascontiguousarray(np.flipud(pixels)))
         rpr_image.set_name(self.name)
 
         if self.color_space in ('sRGB', 'BD16', 'Filmic Log'):

--- a/src/rprblender/export/image.py
+++ b/src/rprblender/export/image.py
@@ -110,7 +110,7 @@ class ImagePixels:
         self.color_space = image.colorspace_settings.name
 
     def export(self, rpr_context, render_size=None, tile=((0, 0), (1, 1))):
-        """ Export pixels cropped to sub-region coordinates as RPR image """
+        """Export pixels cropped to render and tile size as RPR image"""
 
         image_size = self.pixels.shape[1], self.pixels.shape[0]
         if render_size:
@@ -129,12 +129,17 @@ class ImagePixels:
             x1, y1 = 0, 0
             x2, y2 = image_size
 
-        x1, y1, x2, y2 = (x1 + (x2 - x1) * tile[0][0],
-                          y1 + (y2 - y1) * tile[0][1],
-                          x1 + (x2 - x1) * (tile[0][0] + tile[1][0]),
-                          y1 + (y2 - y1) * (tile[0][1] + tile[1][1]))
+        x1, y1, x2, y2 = (
+            int(x1 + (x2 - x1) * tile[0][0]),
+            int(y1 + (y2 - y1) * tile[0][1]),
+            int(x1 + (x2 - x1) * (tile[0][0] + tile[1][0])),
+            int(y1 + (y2 - y1) * (tile[0][1] + tile[1][1]))
+        )
 
-        pixels = self.pixels[int(y1): int(y2), int(x1):int(x2), :]
+        if x1 == x2 or y1 == y2:
+            return None
+
+        pixels = self.pixels[y1:y2, x1:x2, :]
         rpr_image = rpr_context.create_image_data(None, np.ascontiguousarray(np.flipud(pixels)))
         rpr_image.set_name(self.name)
 

--- a/src/rprblender/export/image.py
+++ b/src/rprblender/export/image.py
@@ -21,8 +21,6 @@ import bpy_extras
 
 from rprblender import utils
 
-import pyrpr
-
 from rprblender.utils import logging
 log = logging.Log(tag='export.image')
 
@@ -92,73 +90,54 @@ def sync(rpr_context, image: bpy.types.Image):
 
 
 class ImagePixels:
-    """
-    This class stores source image pixels clipped to region size.
-    Exports full and sub-region pixels
-    """
-    def __init__(self, image: bpy.types.Image, region: tuple):
-        self.pixels = None
-        self.size = (0, 0)
-        self.channels = image.channels
+    """This class stores source image pixels. Exports as tile image and clipped to render size"""
+
+    def __init__(self, image: bpy.types.Image):
+        if image.size[0] * image.size[1] * image.channels == 0:
+            raise ValueError("Image has no data", image)
+
+        pixels = image.pixels
+        if hasattr(pixels, 'foreach_get'):
+            data = utils.get_prop_array_data(pixels)
+        else:
+            # loading image by pixels
+            data = np.fromiter(pixels, dtype=np.float32,
+                               count=image.size[0] * image.size[1] * image.channels)
+
+        data = np.flipud(data.reshape(image.size[1], image.size[0], image.channels))
+        self.pixels = np.ascontiguousarray(data)
+
         self.name = image.name
         self.color_space = image.colorspace_settings.name
 
-        if image.size[0] * image.size[1] * image.channels == 0:
-            log.warn("Image has no data", image)
-            return
-
-        self.pixels = self.extract_pixels(image, *region)
-
-        self.size = (region[2] - region[0] + 1, region[3] - region[1] + 1)
-
-    def is_empty(self) -> bool:
-        return self.pixels is None
-
-    def extract_pixels(self, image: bpy.types.Image, x1, y1, x2, y2) -> np.array:
-        """ Store source image pixels cropped to region coordinates """
-        # extract pixels
-        data = np.fromiter(image.pixels, dtype=np.float32,
-                           count=image.size[0] * image.size[1] * image.channels)
-        pixels = data.reshape(image.size[1], image.size[0], image.channels)
-
-        return self.extract_pixels_region(pixels, x1, y1, x2, y2)
-
-    def extract_pixels_region(self, pixels: np.array, x1, y1, x2, y2) -> np.array:
-        """ Crop pixels to region size """
-        region_pixels = np.array(pixels[y1:y2+1, x1:x2+1, :], dtype=np.float32)
-
-        return region_pixels
-
-    def export(self, rpr_context, region=None) -> (pyrpr.Image, None):
+    def export(self, rpr_context, render_size=None, tile=((0, 0), (1, 1))):
         """ Export pixels cropped to sub-region coordinates as RPR image """
-        if self.is_empty():
-            return None
 
-        if region:
-            x1, y1, x2, y2 = region
-            # check sub-region boundaries, just in case something went terribly wrong
-            if x1 == x2 or y1 == y2 or x1 >= self.size[0] or x2 < 0 or y1 >= self.size[1] or y2 < 0:
-                log.warn(f"Image region ({x1}; {y1})-({x2}; {y2}) has no data", self.name)
-                return None
+        image_size = self.pixels.shape[1], self.pixels.shape[0]
+        if render_size:
+            image_ratio = image_size[0] / image_size[1]
+            render_ratio = render_size[0] / render_size[1]
 
-            image_key = f"{self.name}({x1}, {y1})-({x2}, {y2})@{self.color_space}"
-            if image_key in rpr_context.images:
-                return rpr_context.images[image_key]
+            if image_ratio > render_ratio:
+                size = image_size[1] * render_ratio, image_size[1]
+            else:
+                size = image_size[0], image_size[0] / render_ratio
 
-            # get pixels region
-            pixels = self.extract_pixels_region(self.pixels, x1, y1, x2, y2)
+            x1, y1 = (image_size[0] - size[0]) / 2, (image_size[1] - size[1]) / 2
+            x2, y2 = x1 + size[0], y1 + size[1]
 
         else:
-            image_key = f"{self.name}@{self.color_space}"
-            if image_key in rpr_context.images:
-                return rpr_context.images[image_key]
+            x1, y1 = 0, 0
+            x2, y2 = image_size
 
-            pixels = self.pixels
+        x1, y1, x2, y2 = (x1 + (x2 - x1) * tile[0][0],
+                          y1 + (y2 - y1) * tile[0][1],
+                          x1 + (x2 - x1) * (tile[0][0] + tile[1][0]),
+                          y1 + (y2 - y1) * (tile[0][1] + tile[1][1]))
 
-        pixels = np.ascontiguousarray(np.flipud(pixels))
-        rpr_image = rpr_context.create_image_data(image_key, pixels)
-
-        rpr_image.set_name(image_key)
+        pixels = self.pixels[int(y1): int(y2), int(x1):int(x2), :]
+        rpr_image = rpr_context.create_image_data(None, np.ascontiguousarray(pixels))
+        rpr_image.set_name(self.name)
 
         if self.color_space in ('sRGB', 'BD16', 'Filmic Log'):
             rpr_image.set_gamma(2.2)

--- a/src/rprblender/export/world.py
+++ b/src/rprblender/export/world.py
@@ -103,19 +103,18 @@ class WorldData:
 
         def __init__(self, rpr):
             if rpr.background_image:
-                self.image = rpr.background_image.name
-                image_obj = bpy.data.images[self.image]
+                image_obj = bpy.data.images[rpr.background_image.name]
                 try:
                     self.pixels = ImagePixels(image_obj)
-
                 except ValueError as e:
                     log.warn(e)
-                    self.image = None
                     self.color = WARNING_IMAGE_NOT_DEFINED_COLOR
+                else:
+                    self.image = rpr.background_image.name
+                    self.crop = rpr.backplate_crop
+
             else:
                 self.color = tuple(rpr.background_color)
-
-            self.crop = rpr.backplate_crop
 
         def export(self, rpr_context, render_size, tile=((0, 0), (1, 1))):
             if self.image:

--- a/src/rprblender/properties/world.py
+++ b/src/rprblender/properties/world.py
@@ -238,6 +238,11 @@ class RPR_EnvironmentProperties(RPR_Properties):
         description="Background override type",
         default='SPHERE',
     )
+    backplate_crop: bpy.props.BoolProperty(
+        name="Crop",
+        description="Crop backplate image to render size",
+        default=True,
+    )
 
     # reflection override
     reflection_override: bpy.props.BoolProperty(

--- a/src/rprblender/ui/world.py
+++ b/src/rprblender/ui/world.py
@@ -105,7 +105,12 @@ class RPR_WORLD_PT_background_override(RPR_EnvironmentOverride):
 
         layout.template_ID(rpr, 'background_image', open='image.open', new='image.new')
 
-        row = layout.row()
+        if rpr.background_image_type == 'BACKPLATE':
+            row = layout.column()
+            row.enabled = rpr.background_image is not None
+            row.prop(rpr, 'backplate_crop')
+
+        row = layout.column()
         row.enabled = rpr.background_image is None
         row.prop(rpr, 'background_color')
 

--- a/src/rprblender/utils/__init__.py
+++ b/src/rprblender/utils/__init__.py
@@ -259,3 +259,16 @@ def get_prop_array_data(arr, dtype=np.float32):
 
 def is_zero(val):
     return np.all(np.isclose(val, 0.0))
+
+
+def calculate_image_cropped_size(image_size, render_size):
+    """ Calculate cropped source region size to fit target region aspect ratio """
+    ratio_image = image_size[0] / image_size[1]
+    ratio_render = render_size[0] / render_size[1]
+
+    # crop horizontal size
+    if ratio_image > ratio_render:
+        return image_size[1] * ratio_render, image_size[1]
+
+    # crop vertical size
+    return image_size[0], image_size[0] / ratio_render

--- a/src/rprblender/utils/__init__.py
+++ b/src/rprblender/utils/__init__.py
@@ -259,16 +259,3 @@ def get_prop_array_data(arr, dtype=np.float32):
 
 def is_zero(val):
     return np.all(np.isclose(val, 0.0))
-
-
-def calculate_image_cropped_size(image_size, render_size):
-    """ Calculate cropped source region size to fit target region aspect ratio """
-    ratio_image = image_size[0] / image_size[1]
-    ratio_render = render_size[0] / render_size[1]
-
-    # crop horizontal size
-    if ratio_image > ratio_render:
-        return image_size[1] * ratio_render, image_size[1]
-
-    # crop vertical size
-    return image_size[0], image_size[0] / ratio_render


### PR DESCRIPTION
PURPOSE
1. When disabling background override even if the file is still loaded, the backplate should not show up in production render. 
2. Backplates should work in viewport render.
3. Code related to backplate could be simplified and improved.

EFFECT OF CHANGE
1. Fixed disabling backplate when background override is disabled.
2. Made backplate work in Viewport render.
3. Added "Crop" setting for Backplate panel, which provides option to user to crop background image due to render resolution.

TECHNICAL STEPS
1. Code refactoring:
- simplified image.ImagePixels class, made it to export image including tile.
- moved Backplate class to WorldData internal class as BackplateData. Included its data into comparison of WorldData. Also simplified code in BackplateData and adjusted code world export design.
2. Added backplate_crop to world properties.
3. Enabled backplate in viewport render.