### PR TITLE
RPRBLND-1361: Get blender crash with animation render.

### DIFF
--- a/src/rprblender/engine/animation_engine.py
+++ b/src/rprblender/engine/animation_engine.py
@@ -12,50 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-from .render_engine import RenderEngine
 from .render_engine import RenderEngine, RenderEngine2
-from .image_filter import ImageFilter
 
 
 class AnimationEngine(RenderEngine):
-
-    rpr_context = None
-    image_filter: ImageFilter = None
-
-    def __init__(self, rpr_engine):
-        super().__init__(rpr_engine)
-
-        self.is_last_frame = False
-
-    def _init_rpr_context(self, scene):
-        if not AnimationEngine.rpr_context:
-            AnimationEngine.rpr_context = self._RPRContext()
-            scene.rpr.init_rpr_context(AnimationEngine.rpr_context)
-            AnimationEngine.rpr_context.scene.set_name(scene.name)
-
-        self.rpr_context = AnimationEngine.rpr_context
-
-    def sync(self, depsgraph):
-        super().sync(depsgraph)
-
-        self.is_last_frame = depsgraph.scene.frame_current >= depsgraph.scene.frame_end
-
-    def render(self):
-        try:
-            super().render()
-
-        finally:
-            if self.is_last_frame or self.rpr_engine.test_break():
-                self.rpr_context = AnimationEngine.rpr_context = None
-                self.image_filter = AnimationEngine.image_filter = None
-            else:
-                self.rpr_context.clear_scene()
-
-    def setup_image_filter(self, settings):
-        self.image_filter = AnimationEngine.image_filter
-        super().setup_image_filter(settings)
-        AnimationEngine.image_filter = self.image_filter
+    pass
 
 
-class AnimationEngine2(RenderEngine2, AnimationEngine):
+class AnimationEngine2(RenderEngine2):
     pass

--- a/src/rprblender/engine/animation_engine_hybrid.py
+++ b/src/rprblender/engine/animation_engine_hybrid.py
@@ -13,8 +13,44 @@
 # limitations under the License.
 #********************************************************************
 from . import render_engine_hybrid
-from . import animation_engine
+from .image_filter import ImageFilter
 
 
-class AnimationEngine(render_engine_hybrid.RenderEngine, animation_engine.AnimationEngine):
-    pass
+class AnimationEngine(render_engine_hybrid.RenderEngine):
+
+    rpr_context = None
+    image_filter: ImageFilter = None
+
+    def __init__(self, rpr_engine):
+        super().__init__(rpr_engine)
+
+        self.is_last_frame = False
+
+    def _init_rpr_context(self, scene):
+        if not AnimationEngine.rpr_context:
+            AnimationEngine.rpr_context = self._RPRContext()
+            scene.rpr.init_rpr_context(AnimationEngine.rpr_context)
+            AnimationEngine.rpr_context.scene.set_name(scene.name)
+
+        self.rpr_context = AnimationEngine.rpr_context
+
+    def sync(self, depsgraph):
+        super().sync(depsgraph)
+
+        self.is_last_frame = depsgraph.scene.frame_current >= depsgraph.scene.frame_end
+
+    def render(self):
+        try:
+            super().render()
+
+        finally:
+            if self.is_last_frame or self.rpr_engine.test_break():
+                self.rpr_context = AnimationEngine.rpr_context = None
+                self.image_filter = AnimationEngine.image_filter = None
+            else:
+                self.rpr_context.clear_scene()
+
+    def setup_image_filter(self, settings):
+        self.image_filter = AnimationEngine.image_filter
+        super().setup_image_filter(settings)
+        AnimationEngine.image_filter = self.image_filter


### PR DESCRIPTION
PURPOSE
Animation in Full render quality could have memory leak issue which could produce crash. This is because we don't recreate render context for each frame, instead remove all objects from scene and do reexport. Nevertheless recreating render context for RPR and RPR2 isn't expensive. For hybrid it is still expensive.

EFFECT OF CHANGE
Fixed animation render in Full render quality described in #4.

TECHNICAL STEPS
Moved AnimationEngine implementation to animation_engine_hybrid.py and set AnimationEngine for RPR and RPR2 be equal to RennderEngine and RenderEngine2.