### PR TITLE
Rpr 2.0 fix cpu and label

### DIFF
--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -411,7 +411,7 @@ class RPR_RenderProperties(RPR_Properties):
         ]
 
     def update_render_quality(self, context):
-        if self.render_quality == 'FULL':
+        if self.render_quality in ('FULL', 'FULL2'):
             return
 
         settings = get_user_settings()

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -407,7 +407,7 @@ class RPR_RenderProperties(RPR_Properties):
         ]
     if pyrpr2.enabled:
         render_quality_items += [
-            ('FULL2', "Full (Experimental)", "Full render quality with RPR 2 (Experimental)")
+            ('FULL2', "RPR 2.0 (Beta)", "Full render quality with RPR 2 (Beta)")
         ]
 
     def update_render_quality(self, context):

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -43,7 +43,7 @@ class RPR_RENDER_PT_devices(RPR_Panel):
         else:
             if pyrpr.Context.cpu_device:
                 col = layout.column(align=True)
-                col.enabled = context.scene.rpr.render_quality == 'FULL'
+                col.enabled = context.scene.rpr.render_quality in ('FULL', 'FULL2')
 
                 col.prop(devices, 'cpu_state', text=pyrpr.Context.cpu_device['name'])
                 row = col.row()
@@ -90,7 +90,7 @@ class RPR_RENDER_PT_viewport_devices(RPR_Panel):
         else:
             if pyrpr.Context.cpu_device:
                 col = layout.column(align=True)
-                col.enabled = context.scene.rpr.render_quality == 'FULL'
+                col.enabled = context.scene.rpr.render_quality in ('FULL', 'FULL2')
 
                 col.prop(devices, 'cpu_state', text=pyrpr.Context.cpu_device['name'])
                 row = col.row()


### PR DESCRIPTION
EFFECT:  Enable CPU (and CPU + GPU rendering) in RPR 2.0 in UI.  Also update marketing based on asks.

NOTE:  CPU + GPU rendering should have worked previously, but was disabled in UI.  