### PR TITLE
Reverting back using image cache instead loading images from memory

### DIFF
--- a/src/rprblender/export/image.py
+++ b/src/rprblender/export/image.py
@@ -64,19 +64,13 @@ def sync(rpr_context, image: bpy.types.Image, use_color_space=None):
     log("sync", image)
 
     pixels = image.pixels
-    if hasattr(pixels, 'foreach_get'):
-        data = utils.get_prop_array_data(pixels)
-        data = np.flipud(data.reshape(image.size[1], image.size[0], image.channels))
-        rpr_image = rpr_context.create_image_data(image_key, np.ascontiguousarray(data))
-
-    elif image.source in ('FILE', 'GENERATED'):
+    if image.source in ('FILE', 'GENERATED'):
         file_path = cache_image_file(image, rpr_context.blender_data['depsgraph'])
         rpr_image = rpr_context.create_image_file(image_key, file_path)
 
     else:
         # loading image by pixels
-        data = np.fromiter(pixels, dtype=np.float32,
-                           count=image.size[0] * image.size[1] * image.channels)
+        data = utils.get_prop_array_data(pixels)
         data = np.flipud(data.reshape(image.size[1], image.size[0], image.channels))
         rpr_image = rpr_context.create_image_data(image_key, np.ascontiguousarray(data))
 


### PR DESCRIPTION
PURPOSE
Loading images from blender memory could significantly slowdown export time for some scenes, even using fast foreach_get() method to get image data.

EFFECT OF CHANGE
Reverted back using image cache instead loading images from memory (relates to Blender 2.83+), which should increase speed of export for some scenes.

TECHNICAL STEPS
Made caching images to go before loading from blender memory.