### PR TITLE
RPRBLND-1383: Name collision with collections.

### DIFF
--- a/src/rprblender/export/material.py
+++ b/src/rprblender/export/material.py
@@ -21,11 +21,14 @@ from rprblender.utils import logging
 log = logging.Log(tag='export.Material')
 
 
-def key(material: (str, tuple), *, input_socket_key='Surface'):
-    if input_socket_key == 'Surface':
-        return material
+def key(material: bpy.types.Material, obj=None, input_socket_key='Surface'):
+    mat_key = material.name_full
+    if obj and obj.type=='MESH' and has_uv_map_node(material):
+        mat_key = (mat_key, obj.data.rpr.uv_sets_names)
+    if input_socket_key != 'Surface':
+        mat_key = (mat_key, input_socket_key)
 
-    return (material, input_socket_key)
+    return mat_key
 
 
 def get_material_output_node(material):
@@ -75,12 +78,7 @@ def sync(rpr_context: RPRContext, material: bpy.types.Material, input_socket_key
 
     log(f"sync {material} '{input_socket_key}'; obj {obj}")
 
-    if obj and obj.type=='MESH' and has_uv_map_node(material):
-        # only Mesh objects have UV mapping and RPR data field
-        mat_key = key((material.name, obj.data.rpr.uv_sets_names), input_socket_key=input_socket_key)
-    else:
-        mat_key = key(material.name, input_socket_key=input_socket_key)
-
+    mat_key = key(material, obj, input_socket_key)
     rpr_material = rpr_context.materials.get(mat_key, None)
     if rpr_material:
         return rpr_material
@@ -105,18 +103,13 @@ def sync_update(rpr_context: RPRContext, material: bpy.types.Material, obj: bpy.
 
     log("sync_update", material)
 
-    if obj and obj.type=='MESH' and has_uv_map_node(material):
-        # only Mesh objects have UV mapping and RPR data field
-        mat_key = key((material.name, obj.data.rpr.uv_sets_names),)
-    else:
-        mat_key = key(material.name)
-
+    mat_key = key(material, obj)
     if mat_key in rpr_context.materials:
         rpr_context.remove_material(mat_key)
 
     sync(rpr_context, material, obj=obj)
 
-    displacement_key = key(mat_key, input_socket_key='Displacement')
+    displacement_key = key(material, obj, 'Displacement')
     if displacement_key in rpr_context.materials:
         rpr_context.remove_material(displacement_key)
 

--- a/src/rprblender/export/object.py
+++ b/src/rprblender/export/object.py
@@ -23,7 +23,7 @@ log = logging.Log(tag='export.object')
 
 
 def key(obj: bpy.types.Object):
-    return obj.name
+    return obj.name_full
 
 
 def get_transform(obj: bpy.types.Object):


### PR DESCRIPTION
PURPOSE
Appended object or material from other blend file can be in conflict with existent object or material with same name, which can be rendered as object or material from current scene.

EFFECT OF CHANGE
Fixed rendering objects which were appended from other blend files.

TECHNICAL STEPS
1. Implemented object.key() using object.name_full which is unique over all existed objects included appended (it includes blend file name, if it was appended from another blend file).
2. Implemented material.key() using material.name_full. Also made code improvements there.