### PR TITLE
RPRBLND-1383: Name collision with collections.

### DIFF
--- a/src/rprblender/export/material.py
+++ b/src/rprblender/export/material.py
@@ -23,7 +23,7 @@ log = logging.Log(tag='export.Material')
 
 def key(material: bpy.types.Material, obj=None, input_socket_key='Surface'):
     mat_key = material.name_full
-    if obj and obj.type=='MESH' and has_uv_map_node(material):
+    if obj and obj.type == 'MESH' and has_uv_map_node(material):
         mat_key = (mat_key, obj.data.rpr.uv_sets_names)
     if input_socket_key != 'Surface':
         mat_key = (mat_key, input_socket_key)


### PR DESCRIPTION
PURPOSE
After PR #27 changing material during viewport produces error.

EFFECT OF CHANGE
Fixed changing material during viewport render.

TECHNICAL STEPS
material.key() function was changed in #27, therefore viewport_engine was adjusted. Found that get_object_rpr_materials() can be simplified and removed.