### PR TITLE
RPRBLND-1392: Update Athena for Autotests.

### DIFF
--- a/src/rprblender/config.py
+++ b/src/rprblender/config.py
@@ -26,6 +26,8 @@ material_library_path = None
 enable_hybrid = True
 enable_rpr2 = True
 
+clean_athena_files = True
+
 try:
     # configdev.py example for logging setup:
     # from . import logging

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -480,13 +480,8 @@ class RenderEngine(Engine):
             data[f'GPU{i} Enabled'] = gpu_state
 
         data['Resolution'] = (self.width, self.height)
-        quality = -1 if utils.IS_MAC else self.rpr_context.get_parameter(pyrpr.CONTEXT_RENDER_QUALITY, -1)
-        data['Quality'] = "full" if utils.IS_MAC else {-1: "full",
-                           pyrpr.RENDER_QUALITY_HIGH: "high",
-                           pyrpr.RENDER_QUALITY_MEDIUM: "medium",
-                           pyrpr.RENDER_QUALITY_LOW: "low"}[quality]
         data['Number Lights'] = sum(1 for o in self.rpr_context.scene.objects
-                                 if isinstance(o, pyrpr.Light))
+                                    if isinstance(o, pyrpr.Light))
         data['AOVs Enabled'] = tuple(
             f'RPR_{v}' for v in dir(pyrpr) if v.startswith('AOV_')
             and getattr(pyrpr, v) in self.rpr_context.frame_buffers_aovs
@@ -511,9 +506,14 @@ class RenderEngine(Engine):
 
         data['RIF Type'] = self.image_filter.settings['filter_type'] if self.image_filter else None
 
+        self._update_athena_data(data)
+
         # sending data
         from rprblender.utils import athena
         athena.send_data(data)
+
+    def _update_athena_data(self, data):
+        data['Quality'] = "full"
 
     def prepare_scene_stamp_text(self, scene):
         """ Fill stamp with static scene and render devices info that user can ask for """
@@ -598,3 +598,6 @@ from .context import RPRContext2
 
 class RenderEngine2(RenderEngine):
     _RPRContext = RPRContext2
+
+    def _update_athena_data(self, data):
+        data['Quality'] = "rpr2"

--- a/src/rprblender/engine/render_engine_hybrid.py
+++ b/src/rprblender/engine/render_engine_hybrid.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+import pyrpr
+
 from . import render_engine
 from . import context_hybrid
 
@@ -36,3 +38,10 @@ class RenderEngine(render_engine.RenderEngine):
                 continue
 
             yield obj
+
+    def _update_athena_data(self, data):
+        data['Quality'] = {
+            pyrpr.RENDER_QUALITY_HIGH: "high",
+            pyrpr.RENDER_QUALITY_MEDIUM: "medium",
+            pyrpr.RENDER_QUALITY_LOW: "low"
+        }[self.rpr_context.get_parameter(pyrpr.CONTEXT_RENDER_QUALITY)]

--- a/src/rprblender/utils/athena.py
+++ b/src/rprblender/utils/athena.py
@@ -26,6 +26,7 @@ import bpy
 import pyrpr
 from rprblender import utils
 from rprblender import bl_info
+from rprblender import config
 
 from . import logging
 from . import IS_MAC
@@ -58,10 +59,11 @@ def _send_data_thread(data):
             is_error = True
 
         finally:
-            try:
-                os.remove(file_name)
-            except Exception as e:  # In case removal happens on Blender exit, when temporary folder is already removed
-                log.warn(f"Unable to remove temporary json: {e}")
+            if config.clean_athena_files:
+                try:
+                    os.remove(file_name)
+                except Exception as e:  # In case removal happens on Blender exit, when temporary folder is already removed
+                    log.warn(f"Unable to remove temporary json: {e}")
 
         log("send_data_thread finish")
 


### PR DESCRIPTION
PURPOSE
Team from automation tests on CIS wants to check Athena data which is transferred to AWS. Therefore they asked to provide possibility not to remove corresponded athena json files after sending.

TECHNICAL STEPS
Added config setting clean_athena_files (True by default), by which we can control removing athena json files after sending statistics.