### PR TITLE
Adapt viewport resolution to samples per second

### DIFF
--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -118,10 +118,6 @@ class ViewportSettings:
             ((self.border[0][0] / self.screen_width, self.border[0][1] / self.screen_height),
              (self.border[1][0] / self.screen_width, self.border[1][1] / self.screen_height)))
 
-    @property
-    def resolution(self):
-        return self.width, self.height
-
     def adapt_resolution(self, adapt_render_pixels, prev_settings):
         PIXEL_DIFF = 0.2
         RATIO_DIFF = 0.1

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -28,6 +28,7 @@ from bpy.props import (
     BoolVectorProperty,
     EnumProperty,
     StringProperty,
+    IntVectorProperty
 )
 import platform
 
@@ -67,7 +68,7 @@ class RPR_RenderLimits(bpy.types.PropertyGroup):
 
     adaptive_tile_size: IntProperty(
         name="Adaptive tile size",
-        min=4, default=32, max=64
+        min=4, default=16, max=64
     )
 
     update_samples: IntProperty(
@@ -96,10 +97,23 @@ class RPR_RenderLimits(bpy.types.PropertyGroup):
         min=1, default=4,
     )
 
-    limit_viewport_resolution: BoolProperty(
-        name="Limit Viewport Resolution",
-        description="Limits viewport resolution to final render resolution",
+    adapt_viewport_resolution: BoolProperty(
+        name="Adapt Viewport Resolution",
+        description="Adapts Viewport Resolution for interactivity",
         default=True,
+    )
+
+    viewport_samples_per_sec: IntProperty(
+        name="Samples Per Second",
+        description="Viewport samples per second",
+        default=15,
+    )
+
+    viewport_resolution: IntVectorProperty(
+        name="Viewport Resolution",
+        description="Viewport resolution (may be adaptively set if enabled)",
+        size=2,
+        default=[1980, 1080],
     )
 
     def set_adaptive_params(self, rpr_context):

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -225,7 +225,7 @@ class RPR_UserSettings(bpy.types.PropertyGroup):
         name="Min Resolution Scale",
         description="Min adapt viewport resolution scale",
         subtype='PERCENTAGE',
-        min=5, max=100, default=20,
+        min=5, max=100, default=25,
     )
 
 

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -97,25 +97,6 @@ class RPR_RenderLimits(bpy.types.PropertyGroup):
         min=1, default=4,
     )
 
-    adapt_viewport_resolution: BoolProperty(
-        name="Adapt Viewport Resolution",
-        description="Adapts Viewport Resolution for interactivity",
-        default=True,
-    )
-
-    viewport_samples_per_sec: IntProperty(
-        name="Samples Per Second",
-        description="Viewport samples per second",
-        min=1, soft_max=200, default=15,
-    )
-
-    min_resolution_scale: FloatProperty(
-        name="Min Resolution Scale",
-        description="Min adapt viewport resolution scale",
-        subtype='FACTOR',
-        min=0.05, max=1.0, default=0.2,
-    )
-
     def set_adaptive_params(self, rpr_context):
         """
         Set the adaptive sampling parameters for this context.
@@ -226,6 +207,25 @@ class RPR_UserSettings(bpy.types.PropertyGroup):
             ('4096', '4096', '4096')
         ),
         default='2048',
+    )
+
+    adapt_viewport_resolution: BoolProperty(
+        name="Adapt Viewport Resolution",
+        description="Adapts Viewport Resolution for interactivity",
+        default=True,
+    )
+
+    viewport_samples_per_sec: IntProperty(
+        name="Samples Per Second",
+        description="Viewport samples per second",
+        min=1, soft_max=200, default=15,
+    )
+
+    min_viewport_resolution_scale: IntProperty(
+        name="Min Resolution Scale",
+        description="Min adapt viewport resolution scale",
+        subtype='PERCENTAGE',
+        min=5, max=100, default=20,
     )
 
 

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -109,13 +109,6 @@ class RPR_RenderLimits(bpy.types.PropertyGroup):
         default=15,
     )
 
-    viewport_resolution: IntVectorProperty(
-        name="Viewport Resolution",
-        description="Viewport resolution (may be adaptively set if enabled)",
-        size=2,
-        default=[1980, 1080],
-    )
-
     def set_adaptive_params(self, rpr_context):
         """
         Set the adaptive sampling parameters for this context.

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -106,7 +106,14 @@ class RPR_RenderLimits(bpy.types.PropertyGroup):
     viewport_samples_per_sec: IntProperty(
         name="Samples Per Second",
         description="Viewport samples per second",
-        default=15,
+        min=1, soft_max=200, default=15,
+    )
+
+    min_resolution_scale: FloatProperty(
+        name="Min Resolution Scale",
+        description="Min adapt viewport resolution scale",
+        subtype='FACTOR',
+        min=0.05, max=1.0, default=0.2,
     )
 
     def set_adaptive_params(self, rpr_context):

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -155,8 +155,16 @@ class RPR_RENDER_PT_viewport_limits(RPR_Panel):
         row.prop(limits, 'min_samples')
         col.prop(limits, 'max_samples')
         row = col.row()
-        row.prop(limits, 'noise_threshold', slider = True)
-        col.prop(limits, 'limit_viewport_resolution')
+        row.prop(limits, 'noise_threshold', slider=True)
+        
+        col.prop(limits, 'adapt_viewport_resolution')
+        row = col.row()
+        row.prop(limits, 'viewport_samples_per_sec', slider=True)
+        row.enabled = limits.adapt_viewport_resolution
+        row = col.row()
+        row.prop(limits, 'viewport_resolution')
+        row.enabled = not limits.adapt_viewport_resolution
+        
         col.prop(settings, 'use_gl_interop')
 
         col.separator()

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -158,9 +158,10 @@ class RPR_RENDER_PT_viewport_limits(RPR_Panel):
         row.prop(limits, 'noise_threshold', slider=True)
         
         col.prop(limits, 'adapt_viewport_resolution')
-        row = col.row()
-        row.prop(limits, 'viewport_samples_per_sec', slider=True)
-        row.enabled = limits.adapt_viewport_resolution
+        col1 = col.column(align=True)
+        col1.prop(limits, 'viewport_samples_per_sec', slider=True)
+        col1.prop(limits, 'min_resolution_scale', slider=True)
+        col1.enabled = limits.adapt_viewport_resolution
 
         col.prop(settings, 'use_gl_interop')
 

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -161,10 +161,7 @@ class RPR_RENDER_PT_viewport_limits(RPR_Panel):
         row = col.row()
         row.prop(limits, 'viewport_samples_per_sec', slider=True)
         row.enabled = limits.adapt_viewport_resolution
-        row = col.row()
-        row.prop(limits, 'viewport_resolution')
-        row.enabled = not limits.adapt_viewport_resolution
-        
+
         col.prop(settings, 'use_gl_interop')
 
         col.separator()

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -157,11 +157,11 @@ class RPR_RENDER_PT_viewport_limits(RPR_Panel):
         row = col.row()
         row.prop(limits, 'noise_threshold', slider=True)
         
-        col.prop(limits, 'adapt_viewport_resolution')
+        col.prop(settings, 'adapt_viewport_resolution')
         col1 = col.column(align=True)
-        col1.prop(limits, 'viewport_samples_per_sec', slider=True)
-        col1.prop(limits, 'min_resolution_scale', slider=True)
-        col1.enabled = limits.adapt_viewport_resolution
+        col1.prop(settings, 'viewport_samples_per_sec', slider=True)
+        col1.prop(settings, 'min_viewport_resolution_scale', slider=True)
+        col1.enabled = settings.adapt_viewport_resolution
 
         col.prop(settings, 'use_gl_interop')
 


### PR DESCRIPTION
The idea here is to set a "samples per second" for viewport rendering and adapt the resolution of viewport to reach it.  

TODOS:

- I don't quite get all the resolution setting code, and get a crash there.
- We should probably set a hard floor for downresing resolution
- Encorporate viewport denoising?