### PR TITLE
RPRBLND-1420: Updating to new RIF 1.5.4

### DIFF
--- a/cmd_tools/create_sdk.py
+++ b/cmd_tools/create_sdk.py
@@ -123,13 +123,13 @@ def copy_rif_sdk():
                     str(sdk_bin_dir / "libRadeonImageFilters.dylib"))
         shutil.copy(str(bin_dir / "libOpenImageDenoise.0.9.0.dylib"),
                     str(sdk_bin_dir / "libOpenImageDenoise.dylib"))
-        shutil.copy(str(bin_dir / "libRadeonML-MPS.0.9.7.dylib"),
-                    str(sdk_bin_dir / "libRadeonML-MPS.dylib"))
+        shutil.copy(str(bin_dir / "libRadeonML_MPS.0.9.7.dylib"),
+                    str(sdk_bin_dir / "libRadeonML_MPS.dylib"))
 
         # adjusting id of RIF libs
         install_name_tool('-id', "@rpath/libRadeonImageFilters.dylib", sdk_bin_dir / "libRadeonImageFilters.dylib")
         install_name_tool('-id', "@rpath/libOpenImageDenoise.dylib", sdk_bin_dir / "libOpenImageDenoise.dylib")
-        install_name_tool('-id', "@rpath/libRadeonML-MPS.dylib", sdk_bin_dir / "libRadeonML-MPS.dylib")
+        install_name_tool('-id', "@rpath/libRadeonML_MPS.dylib", sdk_bin_dir / "libRadeonML_MPS.dylib")
 
     else:
         raise KeyError("Unsupported OS", OS)

--- a/cmd_tools/create_sdk.py
+++ b/cmd_tools/create_sdk.py
@@ -109,21 +109,21 @@ def copy_rif_sdk():
             shutil.copy(str(lib), str(sdk_lib_dir))
 
     elif OS == 'Linux':
-        shutil.copy(str(bin_dir / "libRadeonImageFilters.so.1.5.1"),
+        shutil.copy(str(bin_dir / "libRadeonImageFilters.so.1.5.3"),
                     str(sdk_bin_dir / "libRadeonImageFilters.so"))
-        shutil.copy(str(bin_dir / "libRadeonML-MIOpen.so.0.9.2"),
-                    str(sdk_bin_dir / "libRadeonML-MIOpen.so"))
+        shutil.copy(str(bin_dir / "libRadeonML_MIOpen.so.0.9.6"),
+                    str(sdk_bin_dir / "libRadeonML_MIOpen.so"))
         shutil.copy(str(bin_dir / "libOpenImageDenoise.so.0.9.0"),
                     str(sdk_bin_dir / "libOpenImageDenoise.so"))
         shutil.copy(str(bin_dir / "libMIOpen.so.2.0.1"),
                     str(sdk_bin_dir / "libMIOpen.so.2"))
 
     elif OS == 'Darwin':
-        shutil.copy(str(bin_dir / "libRadeonImageFilters.1.5.1.dylib"),
+        shutil.copy(str(bin_dir / "libRadeonImageFilters.1.5.3.dylib"),
                     str(sdk_bin_dir / "libRadeonImageFilters.dylib"))
         shutil.copy(str(bin_dir / "libOpenImageDenoise.0.9.0.dylib"),
                     str(sdk_bin_dir / "libOpenImageDenoise.dylib"))
-        shutil.copy(str(bin_dir / "libRadeonML-MPS.0.9.2.dylib"),
+        shutil.copy(str(bin_dir / "libRadeonML-MPS.0.9.6.dylib"),
                     str(sdk_bin_dir / "libRadeonML-MPS.dylib"))
 
         # adjusting id of RIF libs

--- a/cmd_tools/create_sdk.py
+++ b/cmd_tools/create_sdk.py
@@ -109,9 +109,9 @@ def copy_rif_sdk():
             shutil.copy(str(lib), str(sdk_lib_dir))
 
     elif OS == 'Linux':
-        shutil.copy(str(bin_dir / "libRadeonImageFilters.so.1.5.3"),
+        shutil.copy(str(bin_dir / "libRadeonImageFilters.so.1.5.4"),
                     str(sdk_bin_dir / "libRadeonImageFilters.so"))
-        shutil.copy(str(bin_dir / "libRadeonML_MIOpen.so.0.9.6"),
+        shutil.copy(str(bin_dir / "libRadeonML_MIOpen.so.0.9.7"),
                     str(sdk_bin_dir / "libRadeonML_MIOpen.so"))
         shutil.copy(str(bin_dir / "libOpenImageDenoise.so.0.9.0"),
                     str(sdk_bin_dir / "libOpenImageDenoise.so"))
@@ -119,11 +119,11 @@ def copy_rif_sdk():
                     str(sdk_bin_dir / "libMIOpen.so.2"))
 
     elif OS == 'Darwin':
-        shutil.copy(str(bin_dir / "libRadeonImageFilters.1.5.3.dylib"),
+        shutil.copy(str(bin_dir / "libRadeonImageFilters.1.5.4.dylib"),
                     str(sdk_bin_dir / "libRadeonImageFilters.dylib"))
         shutil.copy(str(bin_dir / "libOpenImageDenoise.0.9.0.dylib"),
                     str(sdk_bin_dir / "libOpenImageDenoise.dylib"))
-        shutil.copy(str(bin_dir / "libRadeonML-MPS.0.9.6.dylib"),
+        shutil.copy(str(bin_dir / "libRadeonML-MPS.0.9.7.dylib"),
                     str(sdk_bin_dir / "libRadeonML-MPS.dylib"))
 
         # adjusting id of RIF libs

--- a/src/bindings/pyrpr/rpr.py
+++ b/src/bindings/pyrpr/rpr.py
@@ -116,8 +116,11 @@ def write_api(api_desc_fpath, f, abi_mode):
         print(name)
         # if a constant is actually a variable to another constant reference that
         if "RPR_" + c.value in api.constants.keys():
-          print('#define', name, pyrprapi.eval_constant(api.constants["RPR_" + c.value].value) if
-          abi_mode else '...' , file=f)
+            print('#define', name, pyrprapi.eval_constant(api.constants["RPR_" + c.value].value)
+                  if abi_mode else '...', file=f)
+        elif "RIF_" + c.value in api.constants.keys():
+            print('#define', name, pyrprapi.eval_constant(api.constants["RIF_" + c.value].value)
+                  if abi_mode else '...', file=f)
         else:
           print('#define', name, pyrprapi.eval_constant(c.value) if abi_mode else '...', file=f)
     for name, t in api.types.items():

--- a/src/bindings/pyrpr/src/pyrprimagefilters.py
+++ b/src/bindings/pyrpr/src/pyrprimagefilters.py
@@ -346,6 +346,9 @@ class CommandQueue(Object):
     def execute(self):
         ContextExecuteCommandQueue(self.context, self, ffi.NULL, ffi.NULL, ffi.NULL)
 
+    def synchronize(self):
+        SyncronizeQueue(self)
+
     def delete(self):
         self.detach_image_filters()
         super().delete()

--- a/src/bindings/pyrpr/src/pyrprimagefilters.py
+++ b/src/bindings/pyrpr/src/pyrprimagefilters.py
@@ -323,6 +323,9 @@ class ImageFilter(Object):
         else:
             raise TypeError("Incorrect type for ImageFilterSetParameter*", self, name, value)
 
+    def set_compute_type(self, compute_type):
+        ImageFilterSetComputeType(self, compute_type)
+
 
 class CommandQueue(Object):
     core_type_name = 'rif_command_queue'

--- a/src/bindings/pyrpr/src/pyrprimagefilters.py
+++ b/src/bindings/pyrpr/src/pyrprimagefilters.py
@@ -291,7 +291,9 @@ class ImageFilter(Object):
         if name in self.parameters and self.parameters[name] == value:
             return
 
-        if isinstance(value, (int, bool)):
+        if name == 'compute_type':
+            ImageFilterSetComputeType(self, value)
+        elif isinstance(value, (int, bool)):
             ImageFilterSetParameter1u(self, pyrpr.encode(name), int(value))
             self.parameters[name] = value
         elif isinstance(value, float):
@@ -322,9 +324,6 @@ class ImageFilter(Object):
             self.parameters[name] = (value, arr)
         else:
             raise TypeError("Incorrect type for ImageFilterSetParameter*", self, name, value)
-
-    def set_compute_type(self, compute_type):
-        ImageFilterSetComputeType(self, compute_type)
 
 
 class CommandQueue(Object):

--- a/src/rprblender/__init__.py
+++ b/src/rprblender/__init__.py
@@ -20,7 +20,7 @@ import bpy
 bl_info = {
     "name": "Radeon ProRender",
     "author": "AMD",
-    "version": (2, 4, 31),
+    "version": (2, 4, 32),
     "blender": (2, 80, 0),
     "location": "Info header, render engine menu",
     "description": "Radeon ProRender rendering plugin for Blender 2.8x",

--- a/src/rprblender/engine/engine.py
+++ b/src/rprblender/engine/engine.py
@@ -281,6 +281,7 @@ class Engine:
 
         elif settings['filter_type'] == 'ML':
             inputs = {'color'}
+            params = {}
 
             if not settings['ml_color_only']:
                 self.rpr_context.enable_aov(pyrpr.AOV_DEPTH)
@@ -288,8 +289,15 @@ class Engine:
                 self.rpr_context.enable_aov(pyrpr.AOV_SHADING_NORMAL)
                 inputs |= {'normal', 'depth', 'albedo'}
 
+            from .viewport_engine import ViewportEngine
+            import pyrprimagefilters as rif
+            if settings['ml_use_fp16_compute_type'] and self.TYPE == ViewportEngine.TYPE:
+                params['compute_type'] = rif.COMPUTE_TYPE_FLOAT16
+            else:
+                params['compute_type'] = rif.COMPUTE_TYPE_FLOAT
+
             self.image_filter = image_filter.ImageFilterML(
-                self.rpr_context.context, inputs, {}, {}, width, height)
+                self.rpr_context.context, inputs, {}, params, width, height)
 
         self.image_filter.settings = settings
 

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -102,6 +102,7 @@ class ImageFilter(metaclass=ABCMeta):
             if isinstance(image, rif.FrameBufferImage):
                 image.update()
 
+        self.command_queue.synchronize()
         self.command_queue.execute()
 
     def get_data(self):

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -24,11 +24,6 @@ from rprblender import utils
 from rprblender.utils.user_settings import get_user_settings
 
 
-# Setting environment variable to enable using FP16 models.
-# In next RIF versions with variable won't be needed and can be removed.
-os.environ['RIF_AI_FP16_ENABLED'] = "1"
-
-
 class ImageFilter(metaclass=ABCMeta):
     def __init__(self, rpr_context: pyrpr.Context, inputs, sigmas, params, width, height,
                  frame_buffer_gl=None):
@@ -172,7 +167,6 @@ class ImageFilterML(ImageFilter):
         else:
             self.filter = self.context.create_filter(rif.IMAGE_FILTER_AI_DENOISE)
 
-        self.filter.set_compute_type(rif.COMPUTE_TYPE_FLOAT16)
         self.filter.set_parameter('useHDR', True)
 
         models_path = utils.package_root_dir() / 'data/models'

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -161,8 +161,7 @@ class ImageFilterML(ImageFilter):
         as well as an albedo '''
     def _create_filter(self):
         devices = self.get_devices()
-        use_oidn = (utils.IS_WIN and devices.cpu_state) 
-        if use_oidn:
+        if devices.cpu_state:
             self.filter = self.context.create_filter(rif.IMAGE_FILTER_OPENIMAGE_DENOISE)
         else:
             self.filter = self.context.create_filter(rif.IMAGE_FILTER_AI_DENOISE)

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -102,10 +102,10 @@ class ImageFilter(metaclass=ABCMeta):
             if isinstance(image, rif.FrameBufferImage):
                 image.update()
 
-        self.command_queue.synchronize()
         self.command_queue.execute()
 
     def get_data(self):
+        self.command_queue.synchronize()
         return self.output_image.get_data()
 
 
@@ -166,6 +166,7 @@ class ImageFilterML(ImageFilter):
         else:
             self.filter = self.context.create_filter(rif.IMAGE_FILTER_AI_DENOISE)
 
+        self.filter.set_compute_type(rif.COMPUTE_TYPE_FLOAT16)
         self.filter.set_parameter('useHDR', True)
 
         models_path = utils.package_root_dir() / 'data/models'

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -161,7 +161,8 @@ class ImageFilterML(ImageFilter):
         as well as an albedo '''
     def _create_filter(self):
         devices = self.get_devices()
-        if devices.cpu_state:
+        use_oidn = (utils.IS_WIN or utils.IS_MAC) and devices.cpu_state
+        if use_oidn:
             self.filter = self.context.create_filter(rif.IMAGE_FILTER_OPENIMAGE_DENOISE)
         else:
             self.filter = self.context.create_filter(rif.IMAGE_FILTER_AI_DENOISE)

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #********************************************************************
 from abc import ABCMeta, abstractmethod
+import os
 
 import pyrpr
 import pyhybrid
@@ -21,6 +22,11 @@ import pyrprimagefilters as rif
 
 from rprblender import utils
 from rprblender.utils.user_settings import get_user_settings
+
+
+# Setting environment variable to enable using FP16 models.
+# In next RIF versions with variable won't be needed and can be removed.
+os.environ['RIF_AI_FP16_ENABLED'] = "1"
 
 
 class ImageFilter(metaclass=ABCMeta):

--- a/src/rprblender/properties/view_layer.py
+++ b/src/rprblender/properties/view_layer.py
@@ -119,7 +119,12 @@ class RPR_DenoiserProperties(RPR_Properties):
         description="Use Color AOV only instead of using additional required AOVs",
         default=True
     )
-
+    ml_use_fp16_compute_type: BoolProperty(
+        name="Use Half-Float Compute",
+        description="Use Float16 compute type. It uses less memory and increases denoising speed but with less quality.\n"
+                    "Available only for viewport render.",
+        default=False
+    )
     def get_settings(self, scene, is_final_engine=True):
         return {
             'enable': self.enable and self.is_available(scene, is_final_engine),
@@ -134,6 +139,7 @@ class RPR_DenoiserProperties(RPR_Properties):
             'half_window': self.half_window,
             'bandwidth': self.bandwidth,
             'ml_color_only': self.ml_color_only,
+            'ml_use_fp16_compute_type': self.ml_use_fp16_compute_type,
         }
 
     def is_available(self, scene, is_final_engine=True):

--- a/src/rprblender/properties/view_layer.py
+++ b/src/rprblender/properties/view_layer.py
@@ -51,7 +51,7 @@ class RPR_DenoiserProperties(RPR_Properties):
         name="Filter Type",
         items=items,
         description="Filter type",
-        default='EAW'
+        default='ML'
     )
 
     scale_by_iterations: BoolProperty(
@@ -117,11 +117,11 @@ class RPR_DenoiserProperties(RPR_Properties):
     ml_color_only: BoolProperty(
         name="Use Color AOV only",
         description="Use Color AOV only instead of using additional required AOVs",
-        default=True
+        default=True if not utils.IS_MAC else False
     )
     ml_use_fp16_compute_type: BoolProperty(
-        name="Use Half-Float Compute",
-        description="Use Float16 compute type. It uses less memory and increases denoising speed but with less quality.\n"
+        name="Use 16-bit Compute",
+        description="Reduce precision to 16 bit. It uses less memory and increases denoising speed, but with less quality.\n"
                     "Available only for viewport render.",
         default=False
     )

--- a/src/rprblender/ui/view_layer.py
+++ b/src/rprblender/ui/view_layer.py
@@ -79,6 +79,7 @@ class RPR_RENDER_PT_denoiser(RPR_Panel):
 
         elif denoiser.filter_type == 'ML':
             col.prop(denoiser, 'ml_color_only')
+            col.prop(denoiser, 'ml_use_fp16_compute_type')
 
         else:
             raise TypeError("No such filter type: %s" % denoiser.filter_type)

--- a/src/rprblender/ui/view_layer.py
+++ b/src/rprblender/ui/view_layer.py
@@ -78,8 +78,9 @@ class RPR_RENDER_PT_denoiser(RPR_Panel):
             col.prop(denoiser, 'bandwidth', slider=True)
 
         elif denoiser.filter_type == 'ML':
-            col.prop(denoiser, 'ml_color_only')
-            col.prop(denoiser, 'ml_use_fp16_compute_type')
+            if not utils.IS_MAC:
+                col.prop(denoiser, 'ml_color_only')
+            # col.prop(denoiser, 'ml_use_fp16_compute_type')
 
         else:
             raise TypeError("No such filter type: %s" % denoiser.filter_type)


### PR DESCRIPTION
PURPOSE
New RIF 1.5.3 is available with some improvements in ML filter using FP16 models.

EFFECT OF CHANGE
Updated to new RIF 1.5.3. Made ML filter to use FP16 models, which could speed up denoising process with less memory usage.

TECHNICAL STEPS
- Switching to latest RIF 1.5.3
- adjusted create_sdk.py and rpr.py
- enabled using FP16 models for ML filter
- added call SynchronizeQueue() before ContextExecuteCommandQueue() which is more correct.