### PR TITLE
RPRBLND-1391: Export to *.rpr to directories which contains non latin chars

### DIFF
--- a/src/bindings/pyrpr/src/pyrpr_load_store.py
+++ b/src/bindings/pyrpr/src/pyrpr_load_store.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #********************************************************************
 import platform
-import _cffi_backend
 from _pyrpr_load_store import ffi
+import pyrpr
 
 lib = None
 
@@ -28,16 +28,13 @@ def init(rpr_sdk_bin_path):
 
 
 def export(name, context, scene, flags):
-
-    file_name = bytes(name, encoding="latin1")
-
     # last param defines export bit flags.
     # image handling type flags:
     # RPRLOADSTORE_EXPORTFLAG_EXTERNALFILES (1 << 0) - image data will be stored to rprsb external file
     # RPRLOADSTORE_EXPORTFLAG_COMPRESS_IMAGE_LEVEL_1 (1 << 1) - image data will be lossless compressed during export
     # RPRLOADSTORE_EXPORTFLAG_COMPRESS_IMAGE_LEVEL_2 (1 << 2) - image data will be lossy compressed during export
     #  note: without any of above flags images will not be exported.
-    return lib.rprsExport(file_name, context._get_handle(), scene._get_handle(),
+    return lib.rprsExport(pyrpr.encode(name), context._get_handle(), scene._get_handle(),
                           0, ffi.NULL, ffi.NULL, 0, ffi.NULL, ffi.NULL, flags)
 
 


### PR DESCRIPTION
PURPOSE
Exporting tto *.rpr to directories which contains non latin chars produces error:
`UnicodeEncodeError: 'latin-1' codec can't encode characters in position 15-19: ordinal not in range(256)`

EFFECT OF CHANGE
Fixed export to *.rpr to directories which contains non latin chars

TECHNICAL STEPS
Fixed by encoding string to utf-8 format.