### PR TITLE
[RPRBLND-952] Unlinked Vector input in procedural texture nodes

### DIFF
--- a/src/rprblender/nodes/blender_nodes.py
+++ b/src/rprblender/nodes/blender_nodes.py
@@ -602,9 +602,7 @@ class ShaderNodeTexChecker(NodeParser):
 
         vector = self.get_input_link('Vector')
         if not vector:
-            vector = self.create_node(pyrpr.MATERIAL_NODE_INPUT_LOOKUP, {
-                pyrpr.MATERIAL_INPUT_VALUE: pyrpr.MATERIAL_NODE_LOOKUP_UV
-            })
+            vector = self.create_generated_uvs()
 
         checker = self.create_node(pyrpr.MATERIAL_NODE_CHECKER_TEXTURE, {
             pyrpr.MATERIAL_INPUT_UV: scale * vector
@@ -1509,9 +1507,7 @@ class ShaderNodeTexGradient(NodeParser):
         ''' create a buffer from ramp data and sample that in nodes if connected '''
         vec = self.get_input_link('Vector')
         if not vec:
-            vec = self.create_node(pyrpr.MATERIAL_NODE_INPUT_LOOKUP, {
-                pyrpr.MATERIAL_INPUT_VALUE: pyrpr.MATERIAL_NODE_LOOKUP_P
-            })
+            vec = self.create_generated_uvs()
 
         gradiant_type = self.node.gradient_type
         x = vec.get_channel(0)
@@ -1645,9 +1641,7 @@ class ShaderNodeTexNoise(NodeParser):
 
         mapping = self.get_input_link('Vector')
         if not mapping:  # use default mapping if no external mapping nodes attached
-            mapping = self.create_node(pyrpr.MATERIAL_NODE_INPUT_LOOKUP, {
-                pyrpr.MATERIAL_INPUT_VALUE: pyrpr.MATERIAL_NODE_LOOKUP_UV
-            })
+            mapping = self.create_generated_uvs()
 
         return self.create_node(pyrpr.MATERIAL_NODE_NOISE2D_TEXTURE, {
             pyrpr.MATERIAL_INPUT_UV: scale * mapping

--- a/src/rprblender/nodes/blender_nodes.py
+++ b/src/rprblender/nodes/blender_nodes.py
@@ -1015,21 +1015,7 @@ class ShaderNodeTexCoord(RuleNodeParser):
         tex_coord_type = self.socket_out.name
 
         if tex_coord_type == 'Generated':
-            data = self.create_node(pyrpr.MATERIAL_NODE_INPUT_LOOKUP, {
-                pyrpr.MATERIAL_INPUT_VALUE: pyrpr.MATERIAL_NODE_LOOKUP_P_LOCAL,
-            })
-            if self.object:
-                # normalize over object bounding box
-                # get min and max of boinding box
-                min_bounds = tuple(min(p[i] for p in self.object.bound_box) for i in range(3))
-                max_bounds = tuple(max(p[i] for p in self.object.bound_box) for i in range(3))
-
-                size = self.node_item((max_bounds[0] - min_bounds[0],
-                                       max_bounds[1] - min_bounds[1],
-                                       max_bounds[2] - min_bounds[2]))
-                min_bounds = self.node_item(min_bounds)
-
-                data = (data - min_bounds) / size
+            data = self.create_generated_uvs()
 
         elif tex_coord_type == 'Normal':
             data = self.create_node(pyrpr.MATERIAL_NODE_INPUT_LOOKUP, {

--- a/src/rprblender/nodes/node_parser.py
+++ b/src/rprblender/nodes/node_parser.py
@@ -347,6 +347,24 @@ class NodeParser(BaseNodeParser):
         input_normal = super().get_input_normal(socket_key)
         return self.node_item(input_normal) if input_normal is not None else self.normal_node
 
+    def create_generated_uvs(self):
+        data = self.create_node(pyrpr.MATERIAL_NODE_INPUT_LOOKUP, {
+            pyrpr.MATERIAL_INPUT_VALUE: pyrpr.MATERIAL_NODE_LOOKUP_P_LOCAL,
+        })
+        if self.object:
+            # normalize over object bounding box
+            # get min and max of boinding box
+            min_bounds = tuple(min(p[i] for p in self.object.bound_box) for i in range(3))
+            max_bounds = tuple(max(p[i] for p in self.object.bound_box) for i in range(3))
+
+            size = self.node_item((max_bounds[0] - min_bounds[0],
+                                   max_bounds[1] - min_bounds[1],
+                                   max_bounds[2] - min_bounds[2]))
+            min_bounds = self.node_item(min_bounds)
+
+            data = (data - min_bounds) / size
+        return data
+
 
 
 class RuleNodeParser(NodeParser):


### PR DESCRIPTION
### PURPOSE
In Cycles the Image Texture node with unlinked Vector(UV) input uses the mesh UV mapping. The procedural texture nodes(such as Noise, Checker, Gradient) are using the Generated UV mapping instead in such case.
The RPR uses UV mapping every time for all supported texture nodes.

To make them more consistent with Cycles result use the Generated UV for supported procedural texture nodes. Leave the Image Texture with UV mapping.

### EFFECT OF CHANGE
- Noise, Checker and Gradient Texture nodes are using Generated UV mapping if Vector input is unlinked.

### TECHNICAL STEPS
- extracted Generated UV mapping coordinates calculations from Texture Coordinates input node as a method;
- used the generated UV mapping for Noise, Checker and Gradient Texture nodes export if Vector input is unlinked.

### NOTES FOR REVIEWERS
- the vertical surfaces have wrong mapping result, just like it was before with Generated UVs;
- the RPR2 doesn't support Generated UV calculations yet.