### PR TITLE
Update RIF 1.6.0

### DIFF
--- a/cmd_tools/create_sdk.py
+++ b/cmd_tools/create_sdk.py
@@ -109,9 +109,9 @@ def copy_rif_sdk():
             shutil.copy(str(lib), str(sdk_lib_dir))
 
     elif OS == 'Linux':
-        shutil.copy(str(bin_dir / "libRadeonImageFilters.so.1.5.4"),
+        shutil.copy(str(bin_dir / "libRadeonImageFilters.so.1.6.0"),
                     str(sdk_bin_dir / "libRadeonImageFilters.so"))
-        shutil.copy(str(bin_dir / "libRadeonML_MIOpen.so.0.9.7"),
+        shutil.copy(str(bin_dir / "libRadeonML_MIOpen.so.0.9.8"),
                     str(sdk_bin_dir / "libRadeonML_MIOpen.so"))
         shutil.copy(str(bin_dir / "libOpenImageDenoise.so.0.9.0"),
                     str(sdk_bin_dir / "libOpenImageDenoise.so"))
@@ -119,11 +119,11 @@ def copy_rif_sdk():
                     str(sdk_bin_dir / "libMIOpen.so.2"))
 
     elif OS == 'Darwin':
-        shutil.copy(str(bin_dir / "libRadeonImageFilters.1.5.4.dylib"),
+        shutil.copy(str(bin_dir / "libRadeonImageFilters.1.6.0.dylib"),
                     str(sdk_bin_dir / "libRadeonImageFilters.dylib"))
         shutil.copy(str(bin_dir / "libOpenImageDenoise.0.9.0.dylib"),
                     str(sdk_bin_dir / "libOpenImageDenoise.dylib"))
-        shutil.copy(str(bin_dir / "libRadeonML_MPS.0.9.7.dylib"),
+        shutil.copy(str(bin_dir / "libRadeonML_MPS.0.9.8.dylib"),
                     str(sdk_bin_dir / "libRadeonML_MPS.dylib"))
 
         # adjusting id of RIF libs

--- a/src/bindings/pyrpr/src/pyrprimagefilters.py
+++ b/src/bindings/pyrpr/src/pyrprimagefilters.py
@@ -74,7 +74,7 @@ def init(log_fun, rprsdk_bin_path):
     del _module
 
 
-API_VERSION = (VERSION_MAJOR << 58) | (VERSION_MINOR << 50) | (VERSION_REVISION << 32) | COMMIT_INFO
+API_VERSION = (VERSION_MAJOR << 56) | (VERSION_MINOR << 48) | (VERSION_REVISION << 32) | COMMIT_INFO
 BACKEND_API = BACKEND_API_METAL if platform.system() == 'Darwin' else BACKEND_API_OPENCL
 
 


### PR DESCRIPTION
### PURPOSE
New RIF 1.6.0 is available.

### EFFECT OF CHANGE
Updating RIF to 1.6.0 version.

### TECHNICAL STEPS
Updated RIF submodule, create_sdk.py and API_VERSION calculation.
