### PR TITLE
Core 1.35.5 update

### DIFF
--- a/src/rprblender/properties/view_layer.py
+++ b/src/rprblender/properties/view_layer.py
@@ -178,7 +178,7 @@ class RPR_ViewLayerProperites(RPR_Properties):
             'channel': 'X'
         },
         {
-            'rpr': pyrpr.AOV_MATERIAL_IDX,
+            'rpr': pyrpr.AOV_MATERIAL_ID,
             'name': "Material Index",
             'channel': 'X'
         },


### PR DESCRIPTION
### PURPOSE
New Core 1.35.5 is available.

### EFFECT OF CHANGE
Update of core SDK to 1.35.5.

### TECHNICAL STEPS
Switched to latest RadeonProRenderSDK submodule. Adjusted const AOV_MATERIAL_ID.
