### PR TITLE
RPRBLND-1423: Optimize render loop for RPR 2.0

### DIFF
--- a/src/RPRBlender.pyproj
+++ b/src/RPRBlender.pyproj
@@ -49,6 +49,7 @@
     <Compile Include="rprblender\engine\render_engine.py" />
     <Compile Include="rprblender\engine\render_engine_hybrid.py" />
     <Compile Include="rprblender\engine\viewport_engine.py" />
+    <Compile Include="rprblender\engine\viewport_engine_2.py" />
     <Compile Include="rprblender\engine\viewport_engine_hybrid.py" />
     <Compile Include="rprblender\engine\__init__.py">
       <SubType>Code</SubType>

--- a/src/bindings/pyrpr/src/pyrpr.py
+++ b/src/bindings/pyrpr/src/pyrpr.py
@@ -357,6 +357,9 @@ class Context(Object):
 
     def render(self):
         ContextRender(self)
+
+    def abort_render(self):
+        ContextAbortRender(self)
         
     def render_tile(self, xmin, xmax, ymin, ymax):
         ContextRenderTile(self, xmin, xmax, ymin, ymax)

--- a/src/bindings/pyrpr/src/pyrpr2.py
+++ b/src/bindings/pyrpr/src/pyrpr2.py
@@ -1,66 +1,79 @@
-import math
-import numpy as np
-
+# **********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
 import pyrpr
-from pyrprwrap import (
-    ContextCreateSphereLight,
-    SphereLightSetRadiantPower3f,
-    SphereLightSetRadius,
-    ContextCreateDiskLight,
-    DiskLightSetRadiantPower3f,
-    DiskLightSetRadius,
-    DiskLightSetAngle,
-)
 
 # will be used in other modules to check if RPR 2 is enabled
 enabled = False
 
 
 class Context(pyrpr.Context):
-    pass
+    def __init__(self, flags: [set, int], props: list = None, use_cache=True):
+        super().__init__(flags, props, use_cache)
+        self.render_update_callback = None
+
+    def set_render_update_callback(self, callback_func):
+        @pyrpr.ffi.callback("void(float, void *)")
+        def render_update_callback(progress, data):
+            callback_func(progress)
+
+        pyrpr.ContextSetParameterByKeyPtr(self, pyrpr.CONTEXT_RENDER_UPDATE_CALLBACK_FUNC,
+                                          render_update_callback)
+        self.render_update_callback = render_update_callback
 
 
 class SphereLight(pyrpr.Light):
     def __init__(self, context):
         super().__init__(context)
-        ContextCreateSphereLight(self.context, self)
+        pyrpr.ContextCreateSphereLight(self.context, self)
 
         # keep target intensity and radius to adjust actual intensity when they are changed
         self._radius_squared = 1
 
     def set_radiant_power(self, r, g, b):
         # Adjust intensity by current radius
-        SphereLightSetRadiantPower3f(self,
-                                     r / self._radius_squared,
-                                     g / self._radius_squared,
-                                     b / self._radius_squared)
+        pyrpr.SphereLightSetRadiantPower3f(self,
+                                           r / self._radius_squared,
+                                           g / self._radius_squared,
+                                           b / self._radius_squared)
 
     def set_radius(self, radius):
         radius = max(radius, 0.01)
         self._radius_squared = radius * radius
-        SphereLightSetRadius(self, radius)
+        pyrpr.SphereLightSetRadius(self, radius)
 
 
 class DiskLight(pyrpr.Light):
     def __init__(self, context):
         super().__init__(context)
-        ContextCreateDiskLight(self.context, self)
+        pyrpr.ContextCreateDiskLight(self.context, self)
 
         # keep target intensity and radius to adjust actual intensity when they are changed
         self._radius_squared = 1
 
     def set_radiant_power(self, r, g, b):
         # Adjust intensity by current radius
-        DiskLightSetRadiantPower3f(self,
+        pyrpr.DiskLightSetRadiantPower3f(self,
                                    r / self._radius_squared,
                                    g / self._radius_squared,
                                    b / self._radius_squared)
 
     def set_cone_shape(self, iangle, oangle):
         # Use external angle oangle
-        DiskLightSetAngle(self, oangle)
+        pyrpr.DiskLightSetAngle(self, oangle)
 
     def set_radius(self, radius):
         radius = max(radius, 0.01)
         self._radius_squared = radius * radius
-        DiskLightSetRadius(self, radius)
+        pyrpr.DiskLightSetRadius(self, radius)

--- a/src/bindings/pyrpr/src/pyrpr2.py
+++ b/src/bindings/pyrpr/src/pyrpr2.py
@@ -24,13 +24,23 @@ class Context(pyrpr.Context):
         self.render_update_callback = None
 
     def set_render_update_callback(self, callback_func):
-        @pyrpr.ffi.callback("void(float, void *)")
-        def render_update_callback(progress, data):
-            callback_func(progress)
+        if callback_func:
+            @pyrpr.ffi.callback("void(float, void *)")
+            def render_update_callback(progress, data):
+                callback_func(progress)
 
-        pyrpr.ContextSetParameterByKeyPtr(self, pyrpr.CONTEXT_RENDER_UPDATE_CALLBACK_FUNC,
-                                          render_update_callback)
-        self.render_update_callback = render_update_callback
+            pyrpr.ContextSetParameterByKeyPtr(self, pyrpr.CONTEXT_RENDER_UPDATE_CALLBACK_FUNC,
+                                              render_update_callback)
+            self.render_update_callback = render_update_callback
+
+        else:
+            pyrpr.ContextSetParameterByKeyPtr(self, pyrpr.CONTEXT_RENDER_UPDATE_CALLBACK_FUNC,
+                                              pyrpr.ffi.NULL)
+            self.render_update_callback = None
+
+    def delete(self):
+        self.set_render_update_callback(None)
+        super().delete()
 
 
 class SphereLight(pyrpr.Light):
@@ -77,3 +87,11 @@ class DiskLight(pyrpr.Light):
         radius = max(radius, 0.01)
         self._radius_squared = radius * radius
         pyrpr.DiskLightSetRadius(self, radius)
+
+
+class PostEffect:
+    def __init__(self, context, post_effect_type):
+        pass
+
+    def set_parameter(self, name, param):
+        pass

--- a/src/rprblender/__init__.py
+++ b/src/rprblender/__init__.py
@@ -20,7 +20,7 @@ import bpy
 bl_info = {
     "name": "Radeon ProRender",
     "author": "AMD",
-    "version": (2, 5, 2),
+    "version": (2, 5, 3),
     "blender": (2, 80, 0),
     "location": "Info header, render engine menu",
     "description": "Radeon ProRender rendering plugin for Blender 2.8x",

--- a/src/rprblender/__init__.py
+++ b/src/rprblender/__init__.py
@@ -47,7 +47,8 @@ from . import (
 
 from .engine.render_engine import RenderEngine, RenderEngine2
 from .engine.preview_engine import PreviewEngine
-from .engine.viewport_engine import ViewportEngine, ViewportEngine2
+from .engine.viewport_engine import ViewportEngine
+from .engine.viewport_engine_2 import ViewportEngine2
 from .engine.animation_engine import AnimationEngine, AnimationEngine2
 
 from .engine.render_engine_hybrid import RenderEngine as RenderEngineHybrid

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -323,9 +323,13 @@ class RPRContext:
             # creating temporary FrameBuffer of required size only to set subdivision
             fb = pyrpr.FrameBuffer(self.context, width, height)
 
-        for obj in objects_with_adaptive_subdivision:
+        self.set_subdivision_on_objects(camera, fb, objects_with_adaptive_subdivision)
+
+    def set_subdivision_on_objects(self, camera, subdivision_framebuffer, objects):
+        """ Apply subdivision to objects using context-specific methods """
+        for obj in objects:
             if isinstance(obj, pyrpr.Shape) and obj.subdivision is not None:
-                obj.set_auto_adapt_subdivision_factor(fb, camera, obj.subdivision['factor'])
+                obj.set_auto_adapt_subdivision_factor(subdivision_framebuffer, camera, obj.subdivision['factor'])
                 obj.set_subdivision_boundary_interop(obj.subdivision['boundary'])
                 obj.set_subdivision_crease_weight(obj.subdivision['crease_weight'])
 
@@ -565,3 +569,12 @@ class RPRContext2(RPRContext):
 
     def sync_catchers(self, use_transparent_background=False):
         pass
+
+    def set_subdivision_on_objects(self, camera, subdivision_framebuffer, objects):
+        # 1.35.4 core version RPR2 doesn't support auto adaptive subdivision, use set_subdivision_factor instead
+        # TODO remove when RPR 2 supports adaptive subdivision
+        for obj in objects:
+            if isinstance(obj, pyrpr.Shape) and obj.subdivision is not None:
+                obj.set_subdivision_factor(obj.subdivision['factor'])
+                obj.set_subdivision_boundary_interop(obj.subdivision['boundary'])
+                obj.set_subdivision_crease_weight(obj.subdivision['crease_weight'])

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -578,3 +578,6 @@ class RPRContext2(RPRContext):
                 obj.set_subdivision_factor(obj.subdivision['factor'])
                 obj.set_subdivision_boundary_interop(obj.subdivision['boundary'])
                 obj.set_subdivision_crease_weight(obj.subdivision['crease_weight'])
+
+    def set_render_update_callback(self, func):
+        self.context.set_render_update_callback(func)

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -120,12 +120,9 @@ class RPRContext:
 
         self.images = {}
 
-    def render(self, *, restart=False, tile=None, iterations=None):
+    def render(self, restart=False, tile=None):
         if restart:
             self.clear_frame_buffers()
-
-        if iterations:
-            self.context.set_parameter(pyrpr.CONTEXT_ITERATIONS, iterations)
 
         if tile is None:
             self.context.render()

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -120,14 +120,20 @@ class RPRContext:
 
         self.images = {}
 
-    def render(self, restart=False, tile=None):
+    def render(self, *, restart=False, tile=None, iterations=None):
         if restart:
             self.clear_frame_buffers()
+
+        if iterations:
+            self.context.set_parameter(pyrpr.CONTEXT_ITERATIONS, iterations)
 
         if tile is None:
             self.context.render()
         else:
             self.context.render_tile(*tile)
+
+    def abort_render(self):
+        self.context.abort_render()
 
     def get_image(self, aov_type=None):
         return self.get_frame_buffer(aov_type).get_data()
@@ -556,6 +562,7 @@ class RPRContext2(RPRContext):
     _Context = pyrpr2.Context
     _SphereLight = pyrpr2.SphereLight
     _DiskLight = pyrpr2.DiskLight
+    _PostEffect = pyrpr2.PostEffect
 
     def init(self, context_flags, context_props):
         context_flags -= {pyrpr.CREATION_FLAGS_ENABLE_GL_INTEROP}

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #********************************************************************
 from abc import ABCMeta, abstractmethod
-import os
 
 import pyrpr
 import pyhybrid
@@ -35,7 +34,10 @@ class ImageFilter(metaclass=ABCMeta):
         # creating context
         creation_flags = rpr_context.get_creation_flags()
         if creation_flags & pyrpr.CREATION_FLAGS_ENABLE_METAL:
-            self.context = rif.ContextMetal(rpr_context)
+            if isinstance(rpr_context, pyrpr2.Context):
+                self.context = rif.Context(rpr_context)
+            else:
+                self.context = rif.ContextMetal(rpr_context)
         elif pyrpr.is_gpu_enabled(creation_flags) and \
                 not isinstance(rpr_context, (pyhybrid.Context, pyrpr2.Context)):
             self.context = rif.ContextOpenCL(rpr_context)

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -627,10 +627,3 @@ class RenderEngine2(RenderEngine):
 
     def _update_athena_data(self, data):
         data['Quality'] = "rpr2"
-
-    def render_update_callback(self, progress):
-        print("render_update_callback", progress)
-
-    def _init_rpr_context(self, scene):
-        super()._init_rpr_context(scene)
-        self.rpr_context.set_render_update_callback(self.render_update_callback)

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -627,3 +627,10 @@ class RenderEngine2(RenderEngine):
 
     def _update_athena_data(self, data):
         data['Quality'] = "rpr2"
+
+    def render_update_callback(self, progress):
+        print("render_update_callback", progress)
+
+    def _init_rpr_context(self, scene):
+        super()._init_rpr_context(scene)
+        self.rpr_context.set_render_update_callback(self.render_update_callback)

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -26,7 +26,7 @@ from bpy_extras import view3d_utils
 
 import pyrpr
 from .engine import Engine
-from rprblender.export import camera, material, world, object, instance, particle
+from rprblender.export import camera, material, world, object, instance
 from rprblender.export.mesh import assign_materials
 from rprblender.utils import gl
 from rprblender import utils
@@ -999,9 +999,3 @@ class ViewportEngine(Engine):
                 continue
 
             yield instance
-        
-
-from .context import RPRContext2
-
-class ViewportEngine2(ViewportEngine):
-    _RPRContext = RPRContext2

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -207,6 +207,10 @@ class ViewportEngine(Engine):
         self.render_iterations = 0
         self.render_time = 0
 
+        self.view_mode = None
+        self.space_data = None
+        self.selected_objects = None
+
         self.user_settings = get_user_settings()
 
     def stop_render(self):

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -174,6 +174,10 @@ class ViewLayerSettings:
         self.material_override = view_layer.material_override
 
 
+class FinishRenderException(Exception):
+    pass
+
+
 class ViewportEngine(Engine):
     """ Viewport render engine """
 
@@ -224,195 +228,198 @@ class ViewportEngine(Engine):
     def _resolve(self):
         self.rpr_context.resolve()
 
+    def notify_status(self, info, status):
+        """ Display export progress status """
+        wrap_info = textwrap.fill(info, 120)
+        self.rpr_engine.update_stats(status, wrap_info)
+        log(status, wrap_info)
+
+        # requesting blender to call draw()
+        self.rpr_engine.tag_redraw()
+
+    def _do_sync(self, depsgraph):
+        # SYNCING OBJECTS AND INSTANCES
+        self.notify_status("Starting...", "Sync")
+        time_begin = time.perf_counter()
+
+        # exporting objects
+        frame_current = depsgraph.scene.frame_current
+        material_override = depsgraph.view_layer.material_override
+        objects_len = len(depsgraph.objects)
+        for i, obj in enumerate(self.depsgraph_objects(depsgraph)):
+            if self.is_finished:
+                raise FinishRenderException
+
+            time_sync = time.perf_counter() - time_begin
+            self.notify_status(f"Time {time_sync:.1f} | Object ({i}/{objects_len}): {obj.name}",
+                               "Sync")
+
+            indirect_only = obj.original.indirect_only_get(view_layer=depsgraph.view_layer)
+            object.sync(self.rpr_context, obj,
+                        indirect_only=indirect_only, material_override=material_override,
+                        frame_current=frame_current)
+
+        # exporting instances
+        instances_len = len(depsgraph.object_instances)
+        last_instances_percent = 0
+
+        for i, inst in enumerate(self.depsgraph_instances(depsgraph)):
+            if self.is_finished:
+                raise FinishRenderException
+
+            instances_percent = (i * 100) // instances_len
+            if instances_percent > last_instances_percent:
+                time_sync = time.perf_counter() - time_begin
+                self.notify_status(f"Time {time_sync:.1f} | Instances {instances_percent}%", "Sync")
+                last_instances_percent = instances_percent
+
+            indirect_only = inst.parent.original.indirect_only_get(view_layer=depsgraph.view_layer)
+            instance.sync(self.rpr_context, inst,
+                          indirect_only=indirect_only, material_override=material_override,
+                          frame_current=frame_current)
+
+        # shadow catcher
+        self.rpr_context.sync_catchers(depsgraph.scene.render.film_transparent)
+
+        self.is_synced = True
+
+    def _do_render(self):
+        # RENDERING
+        self.notify_status("Starting...", "Render")
+
+        is_adaptive = self.rpr_context.is_aov_enabled(pyrpr.AOV_VARIANCE)
+
+        # Infinite cycle, which starts when scene has to be re-rendered.
+        # It waits for restart_render_event be enabled.
+        # Exit from this cycle is implemented through raising FinishRender
+        # when self.is_finished be enabled from main thread.
+        while True:
+            self.restart_render_event.wait()
+
+            if self.is_finished:
+                raise FinishRenderException
+
+            # preparations to start rendering
+            iteration = 0
+            time_begin = 0.0
+            time_render = 0.0
+            if is_adaptive:
+                all_pixels = active_pixels = self.rpr_context.width * self.rpr_context.height
+            is_last_iteration = False
+
+            # this cycle renders each iteration
+            while True:
+                if self.is_finished:
+                    raise FinishRenderException
+
+                is_adaptive_active = is_adaptive and iteration >= self.rpr_context.get_parameter(
+                    pyrpr.CONTEXT_ADAPTIVE_SAMPLING_MIN_SPP)
+
+                if self.restart_render_event.is_set():
+                    # clears restart_render_event, prepares to start rendering
+                    self.restart_render_event.clear()
+                    iteration = 0
+
+                    if self.is_resized:
+                        if not self.rpr_context.gl_interop:
+                            # When gl_interop is not enabled, than resize is better to do in
+                            # this thread. This is important for hybrid.
+                            with self.render_lock:
+                                self.rpr_context.resize(self.width, self.height)
+                        self.is_resized = False
+
+                    self.rpr_context.sync_auto_adapt_subdivision()
+                    self.rpr_context.sync_portal_lights()
+                    time_begin = time.perf_counter()
+                    log(f"Restart render [{self.width}, {self.height}]")
+
+                # rendering
+                with self.render_lock:
+                    if self.restart_render_event.is_set():
+                        break
+
+                    self.rpr_context.set_parameter(pyrpr.CONTEXT_FRAMECOUNT, iteration)
+                    self.rpr_context.render(restart=(iteration == 0))
+
+                # resolving
+                with self.resolve_lock:
+                    self._resolve()
+
+                self.is_rendered = True
+                self.is_denoised = False
+                iteration += 1
+
+                # checking for last iteration
+                # preparing information to show in viewport
+                time_render_prev = time_render
+                time_render = time.perf_counter() - time_begin
+                iteration_time = time_render - time_render_prev
+                if self.user_settings.adapt_viewport_resolution \
+                        and not self.is_resolution_adapted \
+                        and iteration == 2:
+                    target_time = 1.0 / self.user_settings.viewport_samples_per_sec
+                    self.requested_adapt_ratio = target_time / iteration_time
+
+                if self.render_iterations > 0:
+                    info_str = f"Time: {time_render:.1f} sec" \
+                               f" | Iteration: {iteration}/{self.render_iterations}"
+                else:
+                    info_str = f"Time: {time_render:.1f}/{self.render_time} sec" \
+                               f" | Iteration: {iteration}"
+
+                if is_adaptive_active:
+                    active_pixels = self.rpr_context.get_info(pyrpr.CONTEXT_ACTIVE_PIXEL_COUNT, int)
+                    adaptive_progress = max((all_pixels - active_pixels) / all_pixels, 0.0)
+                    info_str += f" | Adaptive Sampling: {math.floor(adaptive_progress * 100)}%"
+
+                if self.render_iterations > 0:
+                    if iteration >= self.render_iterations:
+                        is_last_iteration = True
+                else:
+                    if time_render >= self.render_time:
+                        is_last_iteration = True
+                if is_adaptive and active_pixels == 0:
+                    is_last_iteration = True
+
+                if is_last_iteration:
+                    break
+
+                self.notify_status(info_str, "Render")
+
+            # notifying viewport that rendering is finished
+            if is_last_iteration:
+                time_render = time.perf_counter() - time_begin
+
+                if self.image_filter:
+                    self.notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
+                                       f" | Denoising...", "Render")
+
+                    # applying denoising
+                    with self.resolve_lock:
+                        if self.image_filter:
+                            self.update_image_filter_inputs()
+                            self.image_filter.run()
+                            self.is_denoised = True
+
+                    time_render = time.perf_counter() - time_begin
+                    self.notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
+                                       f" | Denoised", "Rendering Done")
+
+                else:
+                    self.notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}",
+                                       "Rendering Done")
+
     def _do_sync_render(self, depsgraph):
         """
         Thread function for self.sync_render_thread. It always run during viewport render.
         If it doesn't render it waits for self.restart_render_event
         """
 
-        def notify_status(info, status):
-            """ Display export progress status """
-            wrap_info = textwrap.fill(info, 120)
-            self.rpr_engine.update_stats(status, wrap_info)
-            log(status, wrap_info)
-
-            # requesting blender to call draw()
-            self.rpr_engine.tag_redraw()
-
-        class FinishRender(Exception):
-            pass
-
         try:
-            # SYNCING OBJECTS AND INSTANCES
-            notify_status("Starting...", "Sync")
-            time_begin = time.perf_counter()
+            self._do_sync(depsgraph)
+            self._do_render()
 
-            # exporting objects
-            frame_current = depsgraph.scene.frame_current
-            material_override = depsgraph.view_layer.material_override
-            objects_len = len(depsgraph.objects)
-            for i, obj in enumerate(self.depsgraph_objects(depsgraph)):
-                if self.is_finished:
-                    raise FinishRender
-
-                time_sync = time.perf_counter() - time_begin
-                notify_status(f"Time {time_sync:.1f} | Object ({i}/{objects_len}): {obj.name}", "Sync")
-
-                indirect_only = obj.original.indirect_only_get(view_layer=depsgraph.view_layer)
-                object.sync(self.rpr_context, obj,
-                            indirect_only=indirect_only, material_override=material_override,
-                            frame_current=frame_current)
-
-            # exporting instances
-            instances_len = len(depsgraph.object_instances)
-            last_instances_percent = 0
-
-            for i, inst in enumerate(self.depsgraph_instances(depsgraph)):
-                if self.is_finished:
-                    raise FinishRender
-
-                instances_percent = (i * 100) // instances_len
-                if instances_percent > last_instances_percent:
-                    time_sync = time.perf_counter() - time_begin
-                    notify_status(f"Time {time_sync:.1f} | Instances {instances_percent}%", "Sync")
-                    last_instances_percent = instances_percent
-
-                indirect_only = inst.parent.original.indirect_only_get(view_layer=depsgraph.view_layer)
-                instance.sync(self.rpr_context, inst,
-                              indirect_only=indirect_only, material_override=material_override,
-                              frame_current=frame_current)
-
-            # shadow catcher
-            self.rpr_context.sync_catchers(depsgraph.scene.render.film_transparent)
-
-            self.is_synced = True
-
-            # RENDERING
-            notify_status("Starting...", "Render")
-
-            is_adaptive = self.rpr_context.is_aov_enabled(pyrpr.AOV_VARIANCE)
-
-            # Infinite cycle, which starts when scene has to be re-rendered.
-            # It waits for restart_render_event be enabled.
-            # Exit from this cycle is implemented through raising FinishRender
-            # when self.is_finished be enabled from main thread.
-            while True:
-                self.restart_render_event.wait()
-
-                if self.is_finished:
-                    raise FinishRender
-
-                # preparations to start rendering
-                iteration = 0
-                time_begin = 0.0
-                time_render = 0.0
-                if is_adaptive:
-                    all_pixels = active_pixels = self.rpr_context.width * self.rpr_context.height
-                is_last_iteration = False
-
-                # this cycle renders each iteration
-                while True:
-                    if self.is_finished:
-                        raise FinishRender
-
-                    is_adaptive_active = is_adaptive and iteration >= self.rpr_context.get_parameter(
-                        pyrpr.CONTEXT_ADAPTIVE_SAMPLING_MIN_SPP)
-
-                    if self.restart_render_event.is_set():
-                        # clears restart_render_event, prepares to start rendering
-                        self.restart_render_event.clear()
-                        iteration = 0
-                        
-                        if self.is_resized:
-                            if not self.rpr_context.gl_interop:
-                                # When gl_interop is not enabled, than resize is better to do in
-                                # this thread. This is important for hybrid.
-                                with self.render_lock:
-                                    self.rpr_context.resize(self.width, self.height)
-                            self.is_resized = False
-
-                        self.rpr_context.sync_auto_adapt_subdivision()
-                        self.rpr_context.sync_portal_lights()
-                        time_begin = time.perf_counter()
-                        log(f"Restart render [{self.width}, {self.height}]")
-
-                    # rendering
-                    with self.render_lock:
-                        if self.restart_render_event.is_set():
-                            break
-
-                        self.rpr_context.set_parameter(pyrpr.CONTEXT_FRAMECOUNT, iteration)
-                        self.rpr_context.render(restart=(iteration == 0))
-
-                    # resolving
-                    with self.resolve_lock:
-                        self._resolve()
-
-                    self.is_rendered = True
-                    self.is_denoised = False
-                    iteration += 1
-
-                    # checking for last iteration
-                    # preparing information to show in viewport
-                    time_render_prev = time_render
-                    time_render = time.perf_counter() - time_begin
-                    iteration_time = time_render - time_render_prev
-                    if self.user_settings.adapt_viewport_resolution \
-                            and not self.is_resolution_adapted \
-                            and iteration == 2:
-                        target_time = 1.0 / self.user_settings.viewport_samples_per_sec
-                        self.requested_adapt_ratio = target_time / iteration_time
-
-                    if self.render_iterations > 0:
-                        info_str = f"Time: {time_render:.1f} sec"\
-                                   f" | Iteration: {iteration}/{self.render_iterations}"
-                    else:
-                        info_str = f"Time: {time_render:.1f}/{self.render_time} sec"\
-                                   f" | Iteration: {iteration}"
-
-                    if is_adaptive_active:
-                        active_pixels = self.rpr_context.get_info(pyrpr.CONTEXT_ACTIVE_PIXEL_COUNT, int)
-                        adaptive_progress = max((all_pixels - active_pixels) / all_pixels, 0.0)
-                        info_str += f" | Adaptive Sampling: {math.floor(adaptive_progress * 100)}%"
-
-                    if self.render_iterations > 0:
-                        if iteration >= self.render_iterations:
-                            is_last_iteration = True
-                    else:
-                        if time_render >= self.render_time:
-                            is_last_iteration = True
-                    if is_adaptive and active_pixels == 0:
-                        is_last_iteration = True
-
-                    if is_last_iteration:
-                        break
-
-                    notify_status(info_str, "Render")
-
-                # notifying viewport that rendering is finished
-                if is_last_iteration:
-                    time_render = time.perf_counter() - time_begin
-
-                    if self.image_filter:
-                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
-                                      f" | Denoising...", "Render")
-
-                        # applying denoising
-                        with self.resolve_lock:
-                            if self.image_filter:
-                                self.update_image_filter_inputs()
-                                self.image_filter.run()
-                                self.is_denoised = True
-
-                        time_render = time.perf_counter() - time_begin
-                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
-                                      f" | Denoised", "Rendering Done")
-
-                    else:
-                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}",
-                                      "Rendering Done")
-
-        except FinishRender:
+        except FinishRenderException:
             log("Finish by user")
 
         except Exception as e:
@@ -420,7 +427,7 @@ class ViewportEngine(Engine):
             self.is_finished = True
 
             # notifying viewport about error
-            notify_status(f"{e}.\nPlease see logs for more details.", "ERROR")
+            self.notify_status(f"{e}.\nPlease see logs for more details.", "ERROR")
 
         log("Finish _do_sync_render")
 

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -537,6 +537,7 @@ class ViewportEngine(Engine):
             self.view_mode = context.mode
             mode_updated = True
 
+        self._sync_update_before()
         with self.render_lock:
             for update in updates:
                 obj = update.id
@@ -595,6 +596,14 @@ class ViewportEngine(Engine):
 
         if is_updated:
             self.restart_render_event.set()
+
+        self._sync_update_after()
+
+    def _sync_update_before(self):
+        pass
+
+    def _sync_update_after(self):
+        pass
 
     @staticmethod
     def _draw_texture(texture_id, x, y, width, height):

--- a/src/rprblender/engine/viewport_engine_2.py
+++ b/src/rprblender/engine/viewport_engine_2.py
@@ -1,0 +1,411 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import time
+import math
+import traceback
+import textwrap
+
+import pyrpr
+import bgl
+from gpu_extras.presets import draw_texture_2d
+
+from rprblender.export import object, instance
+from .viewport_engine import (
+    ViewportEngine, ViewportSettings,
+    MIN_ADAPT_RESOLUTION_RATIO_DIFF, MIN_ADAPT_RATIO_DIFF
+)
+from .context import RPRContext2
+
+from rprblender.utils import logging
+log = logging.Log(tag='viewport_engine_2')
+
+
+class ViewportEngine2(ViewportEngine):
+    _RPRContext = RPRContext2
+
+    def __init__(self, rpr_engine):
+        super().__init__(rpr_engine)
+
+        self.is_intermediate_render = False
+        self.abort_render_iteration = False
+
+    def stop_render(self):
+        self.abort_render_iteration = True
+        super().stop_render()
+
+    def _do_sync_render(self, depsgraph):
+        """
+        Thread function for self.sync_render_thread. It always run during viewport render.
+        If it doesn't render it waits for self.restart_render_event
+        """
+
+        def notify_status(info, status):
+            """ Display export progress status """
+            wrap_info = textwrap.fill(info, 120)
+            self.rpr_engine.update_stats(status, wrap_info)
+            log(status, wrap_info)
+
+            # requesting blender to call draw()
+            self.rpr_engine.tag_redraw()
+
+        class FinishRender(Exception):
+            pass
+
+        try:
+            # SYNCING OBJECTS AND INSTANCES
+            notify_status("Starting...", "Sync")
+            time_begin = time.perf_counter()
+
+            # exporting objects
+            frame_current = depsgraph.scene.frame_current
+            material_override = depsgraph.view_layer.material_override
+            objects_len = len(depsgraph.objects)
+            for i, obj in enumerate(self.depsgraph_objects(depsgraph)):
+                if self.is_finished:
+                    raise FinishRender
+
+                time_sync = time.perf_counter() - time_begin
+                notify_status(f"Time {time_sync:.1f} | Object ({i}/{objects_len}): {obj.name}",
+                              "Sync")
+
+                indirect_only = obj.original.indirect_only_get(view_layer=depsgraph.view_layer)
+                object.sync(self.rpr_context, obj,
+                            indirect_only=indirect_only, material_override=material_override,
+                            frame_current=frame_current)
+
+            # exporting instances
+            instances_len = len(depsgraph.object_instances)
+            last_instances_percent = 0
+
+            for i, inst in enumerate(self.depsgraph_instances(depsgraph)):
+                if self.is_finished:
+                    raise FinishRender
+
+                instances_percent = (i * 100) // instances_len
+                if instances_percent > last_instances_percent:
+                    time_sync = time.perf_counter() - time_begin
+                    notify_status(f"Time {time_sync:.1f} | Instances {instances_percent}%", "Sync")
+                    last_instances_percent = instances_percent
+
+                indirect_only = inst.parent.original.indirect_only_get(
+                    view_layer=depsgraph.view_layer)
+                instance.sync(self.rpr_context, inst,
+                              indirect_only=indirect_only, material_override=material_override,
+                              frame_current=frame_current)
+
+            # shadow catcher
+            self.rpr_context.sync_catchers(depsgraph.scene.render.film_transparent)
+
+            self.is_synced = True
+
+            # RENDERING
+            iteration = 0
+            time_begin = 0.0
+            time_render = 0.0
+
+            def render_update(progress):
+                if iteration == 0 or progress == 1.0:
+                    return
+
+                if self.abort_render_iteration:
+                    self.abort_render_iteration = False
+                    self.rpr_context.abort_render()
+                    return
+
+                # log("update_render_callback", progress)
+                with self.resolve_lock:
+                    self._resolve()
+
+                time_render = time.perf_counter() - time_begin
+                if self.render_iterations > 0:
+                    info_str = f"Time: {time_render:.1f} sec" \
+                               f" | Iteration: {iteration}/{self.render_iterations}" \
+                               f" {int(progress * 100)}%"
+                else:
+                    info_str = f"Time: {time_render:.1f}/{self.render_time} sec" \
+                               f" | Iteration: {iteration}" \
+                               f" {int(progress * 100)}%"
+
+                self.is_intermediate_render = True
+                self.is_rendered = True
+                notify_status(info_str, "Render")
+
+            self.rpr_context.set_render_update_callback(render_update)
+            self.rpr_context.set_parameter(pyrpr.CONTEXT_ITERATIONS, 32)
+
+            notify_status("Starting...", "Render")
+
+            is_adaptive = self.rpr_context.is_aov_enabled(pyrpr.AOV_VARIANCE)
+
+            # Infinite cycle, which starts when scene has to be re-rendered.
+            # It waits for restart_render_event be enabled.
+            # Exit from this cycle is implemented through raising FinishRender
+            # when self.is_finished be enabled from main thread.
+            while True:
+                self.restart_render_event.wait()
+
+                if self.is_finished:
+                    raise FinishRender
+
+                # preparations to start rendering
+                iteration = 0
+                time_begin = 0.0
+                time_render = 0.0
+                if is_adaptive:
+                    all_pixels = active_pixels = self.rpr_context.width * self.rpr_context.height
+                is_last_iteration = False
+
+                # this cycle renders each iteration
+                while True:
+                    if self.is_finished:
+                        raise FinishRender
+
+                    is_adaptive_active = is_adaptive and iteration >= self.rpr_context.get_parameter(
+                        pyrpr.CONTEXT_ADAPTIVE_SAMPLING_MIN_SPP)
+
+                    if self.restart_render_event.is_set():
+                        # clears restart_render_event, prepares to start rendering
+                        self.restart_render_event.clear()
+                        iteration = 0
+
+                        if self.is_resized:
+                            if not self.rpr_context.gl_interop:
+                                # When gl_interop is not enabled, than resize is better to do in
+                                # this thread. This is important for hybrid.
+                                with self.render_lock:
+                                    self.rpr_context.resize(self.width, self.height)
+                            self.is_resized = False
+
+                        self.rpr_context.sync_auto_adapt_subdivision()
+                        self.rpr_context.sync_portal_lights()
+                        time_begin = time.perf_counter()
+                        log(f"Restart render [{self.width}, {self.height}]")
+
+                    # rendering
+                    with self.render_lock:
+                        if self.restart_render_event.is_set():
+                            break
+
+                        self.rpr_context.set_parameter(pyrpr.CONTEXT_FRAMECOUNT, iteration)
+                        self.rpr_context.render(restart=(iteration == 0),
+                                                iterations=1 if iteration == 0 else 32)
+
+                    # resolving
+                    with self.resolve_lock:
+                        self._resolve()
+
+                    self.is_rendered = True
+                    self.is_denoised = False
+                    iteration += 1
+
+                    # checking for last iteration
+                    # preparing information to show in viewport
+                    time_render_prev = time_render
+                    time_render = time.perf_counter() - time_begin
+                    iteration_time = time_render - time_render_prev
+                    if self.user_settings.adapt_viewport_resolution \
+                            and not self.is_resolution_adapted \
+                            and iteration == 2:
+                        target_time = 1.0 / self.user_settings.viewport_samples_per_sec
+                        self.requested_adapt_ratio = target_time / iteration_time
+
+                    if self.render_iterations > 0:
+                        info_str = f"Time: {time_render:.1f} sec" \
+                                   f" | Iteration: {iteration}/{self.render_iterations}"
+                    else:
+                        info_str = f"Time: {time_render:.1f}/{self.render_time} sec" \
+                                   f" | Iteration: {iteration}"
+
+                    if is_adaptive_active:
+                        active_pixels = self.rpr_context.get_info(pyrpr.CONTEXT_ACTIVE_PIXEL_COUNT,
+                                                                  int)
+                        adaptive_progress = max((all_pixels - active_pixels) / all_pixels, 0.0)
+                        info_str += f" | Adaptive Sampling: {math.floor(adaptive_progress * 100)}%"
+
+                    if self.render_iterations > 0:
+                        if iteration >= self.render_iterations:
+                            is_last_iteration = True
+                    else:
+                        if time_render >= self.render_time:
+                            is_last_iteration = True
+                    if is_adaptive and active_pixels == 0:
+                        is_last_iteration = True
+
+                    if is_last_iteration:
+                        break
+
+                    self.is_intermediate_render = False
+                    notify_status(info_str, "Render")
+
+                # notifying viewport that rendering is finished
+                if is_last_iteration:
+                    time_render = time.perf_counter() - time_begin
+
+                    if self.image_filter:
+                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
+                                      f" | Denoising...", "Render")
+
+                        # applying denoising
+                        with self.resolve_lock:
+                            if self.image_filter:
+                                self.update_image_filter_inputs()
+                                self.image_filter.run()
+                                self.is_denoised = True
+
+                        time_render = time.perf_counter() - time_begin
+                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
+                                      f" | Denoised", "Rendering Done")
+
+                    else:
+                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}",
+                                      "Rendering Done")
+
+        except FinishRender:
+            log("Finish by user")
+
+        except Exception as e:
+            log.error(e, 'EXCEPTION:', traceback.format_exc())
+            self.is_finished = True
+
+            # notifying viewport about error
+            notify_status(f"{e}.\nPlease see logs for more details.", "ERROR")
+
+        log("Finish _do_sync_render")
+
+    def draw(self, context):
+        log("Draw")
+
+        if not self.is_synced or self.is_finished:
+            return
+
+        scene = context.scene
+
+        # initializing self.viewport_settings and requesting first self.restart_render_event
+        if not self.viewport_settings:
+            self.viewport_settings = ViewportSettings(context)
+
+            self.viewport_settings.export_camera(self.rpr_context.scene.camera)
+            self._resize(self.viewport_settings.width, self.viewport_settings.height)
+            self.is_resolution_adapted = False
+            self.restart_render_event.set()
+
+        if not self.is_rendered:
+            return
+
+        # drawing functionality
+        def draw_(texture_id):
+            if scene.rpr.render_mode in ('WIREFRAME', 'MATERIAL_INDEX',
+                                         'POSITION', 'NORMAL', 'TEXCOORD'):
+                # Draw without color management
+                draw_texture_2d(texture_id, self.viewport_settings.border[0],
+                                *self.viewport_settings.border[1])
+
+            else:
+                # Bind shader that converts from scene linear to display space,
+                bgl.glEnable(bgl.GL_BLEND)
+                bgl.glBlendFunc(bgl.GL_ONE, bgl.GL_ONE_MINUS_SRC_ALPHA)
+                self.rpr_engine.bind_display_space_shader(scene)
+
+                # note this has to draw to region size, not scaled down size
+                self._draw_texture(texture_id, *self.viewport_settings.border[0],
+                                   *self.viewport_settings.border[1])
+
+                self.rpr_engine.unbind_display_space_shader()
+                bgl.glDisable(bgl.GL_BLEND)
+
+        def draw__():
+            if self.is_denoised:
+                im = None
+                with self.resolve_lock:
+                    if self.image_filter:
+                        im = self.image_filter.get_data()
+
+                if im is not None:
+                    self.gl_texture.set_image(im)
+                    draw_(self.gl_texture.texture_id)
+                    return
+
+            if self.rpr_context.gl_interop:
+                with self.resolve_lock:
+                    draw_(self.rpr_context.get_frame_buffer().texture_id)
+                return
+
+            with self.resolve_lock:
+                im = self._get_render_image()
+
+            self.gl_texture.set_image(im)
+            draw_(self.gl_texture.texture_id)
+
+        draw__()
+
+        # checking for viewport updates: setting camera position and resizing
+        viewport_settings = ViewportSettings(context)
+
+        if viewport_settings.width * viewport_settings.height == 0:
+            return
+
+        if self.viewport_settings != viewport_settings:
+            self.abort_render_iteration = True
+            with self.render_lock:
+                self.viewport_settings = viewport_settings
+                self.viewport_settings.export_camera(self.rpr_context.scene.camera)
+                if self.user_settings.adapt_viewport_resolution:
+                    # trying to use previous resolution or almost same pixels number
+                    max_w, max_h = self.viewport_settings.width, self.viewport_settings.height
+                    min_w = max(max_w * self.user_settings.min_viewport_resolution_scale // 100, 1)
+                    min_h = max(max_h * self.user_settings.min_viewport_resolution_scale // 100, 1)
+                    w, h = self.rpr_context.width, self.rpr_context.height
+
+                    if abs(w / h - max_w / max_h) > MIN_ADAPT_RESOLUTION_RATIO_DIFF:
+                        scale = math.sqrt(w * h / (max_w * max_h))
+                        w, h = int(max_w * scale), int(max_h * scale)
+
+                    self._resize(min(max(w, min_w), max_w),
+                                 min(max(h, min_h), max_h))
+                else:
+                    self._resize(self.viewport_settings.width, self.viewport_settings.height)
+
+                self.is_resolution_adapted = False
+                self.restart_render_event.set()
+
+        else:
+            if self.requested_adapt_ratio is not None:
+                self.abort_render_iteration = True
+                with self.render_lock:
+                    max_w, max_h = self.viewport_settings.width, self.viewport_settings.height
+                    min_w = max(max_w * self.user_settings.min_viewport_resolution_scale // 100, 1)
+                    min_h = max(max_h * self.user_settings.min_viewport_resolution_scale // 100, 1)
+                    if abs(1.0 - self.requested_adapt_ratio) > MIN_ADAPT_RATIO_DIFF:
+                        scale = math.sqrt(self.requested_adapt_ratio)
+                        w, h = int(self.rpr_context.width * scale),\
+                               int(self.rpr_context.height * scale)
+                    else:
+                        w, h = self.rpr_context.width, self.rpr_context.height
+
+                    self._resize(min(max(w, min_w), max_w),
+                                 min(max(h, min_h), max_h))
+
+                    self.requested_adapt_ratio = None
+                    self.is_resolution_adapted = True
+
+            elif not self.user_settings.adapt_viewport_resolution:
+                if self.width != self.viewport_settings.width or \
+                        self.height != self.viewport_settings.height:
+                    self.abort_render_iteration = True
+                    with self.render_lock:
+                        self._resize(self.viewport_settings.width, self.viewport_settings.height)
+
+            if self.is_resized:
+                self.restart_render_event.set()

--- a/src/rprblender/engine/viewport_engine_2.py
+++ b/src/rprblender/engine/viewport_engine_2.py
@@ -24,8 +24,7 @@ from gpu_extras.presets import draw_texture_2d
 
 from rprblender.export import object, instance
 from .viewport_engine import (
-    ViewportEngine, ViewportSettings, ShadingData,
-    MIN_ADAPT_RESOLUTION_RATIO_DIFF, MIN_ADAPT_RATIO_DIFF
+    ViewportEngine, ViewportSettings, ShadingData, FinishRenderException
 )
 from .context import RPRContext2
 
@@ -46,245 +45,163 @@ class ViewportEngine2(ViewportEngine):
         self.abort_render_iteration = True
         super().stop_render()
 
-    def _do_sync_render(self, depsgraph):
-        """
-        Thread function for self.sync_render_thread. It always run during viewport render.
-        If it doesn't render it waits for self.restart_render_event
-        """
+    def _do_render(self):
+        iteration = 0
+        time_begin = 0.0
+        time_render = 0.0
 
-        def notify_status(info, status):
-            """ Display export progress status """
-            wrap_info = textwrap.fill(info, 120)
-            self.rpr_engine.update_stats(status, wrap_info)
-            log(status, wrap_info)
+        update_iterations = 1
 
-            # requesting blender to call draw()
-            self.rpr_engine.tag_redraw()
+        def render_update(progress):
+            # if iteration == 0:
+            #     return
 
-        class FinishRender(Exception):
-            pass
+            if progress == 1.0:
+                return
 
-        try:
-            # SYNCING OBJECTS AND INSTANCES
-            notify_status("Starting...", "Sync")
-            time_begin = time.perf_counter()
+            if self.abort_render_iteration:
+                self.abort_render_iteration = False
+                self.rpr_context.abort_render()
+                return
 
-            # exporting objects
-            frame_current = depsgraph.scene.frame_current
-            material_override = depsgraph.view_layer.material_override
-            objects_len = len(depsgraph.objects)
-            for i, obj in enumerate(self.depsgraph_objects(depsgraph)):
-                if self.is_finished:
-                    raise FinishRender
+            # log("update_render_callback", progress)
+            with self.resolve_lock:
+                self._resolve()
 
-                time_sync = time.perf_counter() - time_begin
-                notify_status(f"Time {time_sync:.1f} | Object ({i}/{objects_len}): {obj.name}",
-                              "Sync")
+            time_render = time.perf_counter() - time_begin
+            it = iteration + int(update_iterations * progress)
+            if self.render_iterations > 0:
+                info_str = f"Time: {time_render:.1f} sec" \
+                           f" | Iteration: {it}/{self.render_iterations}"
+            else:
+                info_str = f"Time: {time_render:.1f}/{self.render_time} sec" \
+                           f" | Iteration: {it}"
 
-                indirect_only = obj.original.indirect_only_get(view_layer=depsgraph.view_layer)
-                object.sync(self.rpr_context, obj,
-                            indirect_only=indirect_only, material_override=material_override,
-                            frame_current=frame_current)
+            self.is_intermediate_render = True
+            self.is_rendered = True
+            self.notify_status(info_str, "Render")
 
-            # exporting instances
-            instances_len = len(depsgraph.object_instances)
-            last_instances_percent = 0
+        self.rpr_context.set_render_update_callback(render_update)
+        self.rpr_context.set_parameter(pyrpr.CONTEXT_ITERATIONS, 32)
 
-            for i, inst in enumerate(self.depsgraph_instances(depsgraph)):
-                if self.is_finished:
-                    raise FinishRender
+        self.notify_status("Starting...", "Render")
 
-                instances_percent = (i * 100) // instances_len
-                if instances_percent > last_instances_percent:
-                    time_sync = time.perf_counter() - time_begin
-                    notify_status(f"Time {time_sync:.1f} | Instances {instances_percent}%", "Sync")
-                    last_instances_percent = instances_percent
+        is_adaptive = self.rpr_context.is_aov_enabled(pyrpr.AOV_VARIANCE)
 
-                indirect_only = inst.parent.original.indirect_only_get(
-                    view_layer=depsgraph.view_layer)
-                instance.sync(self.rpr_context, inst,
-                              indirect_only=indirect_only, material_override=material_override,
-                              frame_current=frame_current)
+        # Infinite cycle, which starts when scene has to be re-rendered.
+        # It waits for restart_render_event be enabled.
+        # Exit from this cycle is implemented through raising FinishRender
+        # when self.is_finished be enabled from main thread.
+        while True:
+            self.restart_render_event.wait()
 
-            # shadow catcher
-            self.rpr_context.sync_catchers(depsgraph.scene.render.film_transparent)
+            if self.is_finished:
+                raise FinishRenderException
 
-            self.is_synced = True
-
-            # RENDERING
+            # preparations to start rendering
             iteration = 0
             time_begin = 0.0
             time_render = 0.0
+            if is_adaptive:
+                all_pixels = active_pixels = self.rpr_context.width * self.rpr_context.height
+            is_last_iteration = False
 
-            update_iterations = 1
+            # this cycle renders each iteration
+            while True:
+                if self.is_finished:
+                    raise FinishRenderException
 
-            def render_update(progress):
-                # if iteration == 0:
-                #     return
+                is_adaptive_active = is_adaptive and iteration >= self.rpr_context.get_parameter(
+                    pyrpr.CONTEXT_ADAPTIVE_SAMPLING_MIN_SPP)
 
-                if progress == 1.0:
-                    return
+                if self.restart_render_event.is_set():
+                    # clears restart_render_event, prepares to start rendering
+                    self.restart_render_event.clear()
+                    iteration = 0
 
-                if self.abort_render_iteration:
-                    self.abort_render_iteration = False
-                    self.rpr_context.abort_render()
-                    return
+                    if self.is_resized:
+                        if not self.rpr_context.gl_interop:
+                            # When gl_interop is not enabled, than resize is better to do in
+                            # this thread. This is important for hybrid.
+                            with self.render_lock:
+                                self.rpr_context.resize(self.width, self.height)
+                        self.is_resized = False
 
-                # log("update_render_callback", progress)
+                    self.rpr_context.sync_auto_adapt_subdivision()
+                    self.rpr_context.sync_portal_lights()
+                    time_begin = time.perf_counter()
+                    log(f"Restart render [{self.width}, {self.height}]")
+
+                # rendering
+                with self.render_lock:
+                    if self.restart_render_event.is_set():
+                        break
+
+                    self.rpr_context.set_parameter(pyrpr.CONTEXT_FRAMECOUNT, iteration)
+                    update_iterations = 1 if iteration == 0 else \
+                        min(32, self.render_iterations - iteration)
+                    self.rpr_context.set_parameter(pyrpr.CONTEXT_ITERATIONS, update_iterations)
+                    self.rpr_context.render(restart=(iteration == 0))
+
+                # resolving
                 with self.resolve_lock:
                     self._resolve()
 
+                self.is_rendered = True
+                self.is_denoised = False
+                iteration += update_iterations
                 time_render = time.perf_counter() - time_begin
-                it = iteration + int(update_iterations * progress)
+
                 if self.render_iterations > 0:
                     info_str = f"Time: {time_render:.1f} sec" \
-                               f" | Iteration: {it}/{self.render_iterations}"
+                               f" | Iteration: {iteration}/{self.render_iterations}"
                 else:
                     info_str = f"Time: {time_render:.1f}/{self.render_time} sec" \
-                               f" | Iteration: {it}"
+                               f" | Iteration: {iteration}"
 
-                self.is_intermediate_render = True
-                self.is_rendered = True
-                notify_status(info_str, "Render")
+                if is_adaptive_active:
+                    active_pixels = self.rpr_context.get_info(pyrpr.CONTEXT_ACTIVE_PIXEL_COUNT,
+                                                              int)
+                    adaptive_progress = max((all_pixels - active_pixels) / all_pixels, 0.0)
+                    info_str += f" | Adaptive Sampling: {math.floor(adaptive_progress * 100)}%"
 
-            self.rpr_context.set_render_update_callback(render_update)
-            self.rpr_context.set_parameter(pyrpr.CONTEXT_ITERATIONS, 32)
-
-            notify_status("Starting...", "Render")
-
-            is_adaptive = self.rpr_context.is_aov_enabled(pyrpr.AOV_VARIANCE)
-
-            # Infinite cycle, which starts when scene has to be re-rendered.
-            # It waits for restart_render_event be enabled.
-            # Exit from this cycle is implemented through raising FinishRender
-            # when self.is_finished be enabled from main thread.
-            while True:
-                self.restart_render_event.wait()
-
-                if self.is_finished:
-                    raise FinishRender
-
-                # preparations to start rendering
-                iteration = 0
-                time_begin = 0.0
-                time_render = 0.0
-                if is_adaptive:
-                    all_pixels = active_pixels = self.rpr_context.width * self.rpr_context.height
-                is_last_iteration = False
-
-                # this cycle renders each iteration
-                while True:
-                    if self.is_finished:
-                        raise FinishRender
-
-                    is_adaptive_active = is_adaptive and iteration >= self.rpr_context.get_parameter(
-                        pyrpr.CONTEXT_ADAPTIVE_SAMPLING_MIN_SPP)
-
-                    if self.restart_render_event.is_set():
-                        # clears restart_render_event, prepares to start rendering
-                        self.restart_render_event.clear()
-                        iteration = 0
-
-                        if self.is_resized:
-                            if not self.rpr_context.gl_interop:
-                                # When gl_interop is not enabled, than resize is better to do in
-                                # this thread. This is important for hybrid.
-                                with self.render_lock:
-                                    self.rpr_context.resize(self.width, self.height)
-                            self.is_resized = False
-
-                        self.rpr_context.sync_auto_adapt_subdivision()
-                        self.rpr_context.sync_portal_lights()
-                        time_begin = time.perf_counter()
-                        log(f"Restart render [{self.width}, {self.height}]")
-
-                    # rendering
-                    with self.render_lock:
-                        if self.restart_render_event.is_set():
-                            break
-
-                        self.rpr_context.set_parameter(pyrpr.CONTEXT_FRAMECOUNT, iteration)
-                        update_iterations = 1 if iteration == 0 else \
-                            min(32, self.render_iterations - iteration)
-                        self.rpr_context.set_parameter(pyrpr.CONTEXT_ITERATIONS, update_iterations)
-                        self.rpr_context.render(restart=(iteration == 0))
-
-                    # resolving
-                    with self.resolve_lock:
-                        self._resolve()
-
-                    self.is_rendered = True
-                    self.is_denoised = False
-                    iteration += update_iterations
-
-                    # checking for last iteration
-                    # preparing information to show in viewport
-                    time_render_prev = time_render
-                    time_render = time.perf_counter() - time_begin
-                    iteration_time = time_render - time_render_prev
-
-                    if self.render_iterations > 0:
-                        info_str = f"Time: {time_render:.1f} sec" \
-                                   f" | Iteration: {iteration}/{self.render_iterations}"
-                    else:
-                        info_str = f"Time: {time_render:.1f}/{self.render_time} sec" \
-                                   f" | Iteration: {iteration}"
-
-                    if is_adaptive_active:
-                        active_pixels = self.rpr_context.get_info(pyrpr.CONTEXT_ACTIVE_PIXEL_COUNT,
-                                                                  int)
-                        adaptive_progress = max((all_pixels - active_pixels) / all_pixels, 0.0)
-                        info_str += f" | Adaptive Sampling: {math.floor(adaptive_progress * 100)}%"
-
-                    if self.render_iterations > 0:
-                        if iteration >= self.render_iterations:
-                            is_last_iteration = True
-                    else:
-                        if time_render >= self.render_time:
-                            is_last_iteration = True
-                    if is_adaptive and active_pixels == 0:
+                if self.render_iterations > 0:
+                    if iteration >= self.render_iterations:
                         is_last_iteration = True
+                else:
+                    if time_render >= self.render_time:
+                        is_last_iteration = True
+                if is_adaptive and active_pixels == 0:
+                    is_last_iteration = True
 
-                    if is_last_iteration:
-                        break
-
-                    self.is_intermediate_render = False
-                    notify_status(info_str, "Render")
-
-                # notifying viewport that rendering is finished
                 if is_last_iteration:
+                    break
+
+                self.is_intermediate_render = False
+                self.notify_status(info_str, "Render")
+
+            # notifying viewport that rendering is finished
+            if is_last_iteration:
+                time_render = time.perf_counter() - time_begin
+
+                if self.image_filter:
+                    self.notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
+                                       f" | Denoising...", "Render")
+
+                    # applying denoising
+                    with self.resolve_lock:
+                        if self.image_filter:
+                            self.update_image_filter_inputs()
+                            self.image_filter.run()
+                            self.is_denoised = True
+
                     time_render = time.perf_counter() - time_begin
+                    self.notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
+                                       f" | Denoised", "Rendering Done")
 
-                    if self.image_filter:
-                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
-                                      f" | Denoising...", "Render")
-
-                        # applying denoising
-                        with self.resolve_lock:
-                            if self.image_filter:
-                                self.update_image_filter_inputs()
-                                self.image_filter.run()
-                                self.is_denoised = True
-
-                        time_render = time.perf_counter() - time_begin
-                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}"
-                                      f" | Denoised", "Rendering Done")
-
-                    else:
-                        notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}",
-                                      "Rendering Done")
-
-        except FinishRender:
-            log("Finish by user")
-
-        except Exception as e:
-            log.error(e, 'EXCEPTION:', traceback.format_exc())
-            self.is_finished = True
-
-            # notifying viewport about error
-            notify_status(f"{e}.\nPlease see logs for more details.", "ERROR")
-
-        log("Finish _do_sync_render")
+                else:
+                    self.notify_status(f"Time: {time_render:.1f} sec | Iteration: {iteration}",
+                                       "Rendering Done")
 
     def draw(self, context):
         log("Draw")

--- a/src/rprblender/properties/view_layer.py
+++ b/src/rprblender/properties/view_layer.py
@@ -143,7 +143,7 @@ class RPR_DenoiserProperties(RPR_Properties):
         }
 
     def is_available(self, scene, is_final_engine=True):
-        return scene.rpr.render_quality != 'FULL2'
+        return True
 
 
 class RPR_ViewLayerProperites(RPR_Properties):

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -160,11 +160,15 @@ class RPR_RENDER_PT_viewport_limits(RPR_Panel):
         if context.scene.rpr.render_quality == 'FULL2':
             row.enabled = False
 
-        col.prop(settings, 'adapt_viewport_resolution')
+        adapt_resolution = context.scene.rpr.render_quality != 'FULL2'
+        col1 = col.column()
+        col1.enabled = adapt_resolution
+        col1.prop(settings, 'adapt_viewport_resolution')
+
         col1 = col.column(align=True)
+        col1.enabled = settings.adapt_viewport_resolution and adapt_resolution
         col1.prop(settings, 'viewport_samples_per_sec', slider=True)
         col1.prop(settings, 'min_viewport_resolution_scale', slider=True)
-        col1.enabled = settings.adapt_viewport_resolution
 
         col.prop(settings, 'use_gl_interop')
 


### PR DESCRIPTION
### PURPOSE
RPR 2.0 provides features with update render callback to get intermediate render results during ContextRender and more optimized when using bigger iteration parameter.

### EFFECT OF CHANGE
Provided new more optimized viewport rendering algorithm for RPR 2.0. 
Enabled denoising for RPR 2.0 in viewport.

### TECHNICAL STEPS
1. In pyrpr wrappers:
- added pyrpr2.Context.set_render_update_callback() function to set the callback
- added pyrpr.Context.abort_render()
- set empty PostEffect for pyrpr2
- code improvement in pyrpr2
2. Moved ViewportEngine2 into viewport_engine_2.py.
3. Refactored ViewportEngine to be able to use in ViewportEngine2: 
- splitted _do_sync_render() into _do_sync(), _do_render()
- splitted draw()
4. In ViewportEngine2 _do_render() and draw() were completely rewritten.
5. Enabled denoiser for RPR 2.0 and fixed it in MacOS.

### NOTES FOR REVIEWERS
Seems RPR 2.0 is quite slow in MacOS, therefore it slightly hungs during viewport updates.