### PR TITLE
RPRBLND-1471: Possible error in parsing ShaderNodeRGBCurve.

### DIFF
--- a/src/rprblender/nodes/blender_nodes.py
+++ b/src/rprblender/nodes/blender_nodes.py
@@ -1643,9 +1643,9 @@ class ShaderNodeRGBCurve(NodeParser):
 
         out_col = tuple(
             self.eval_curve(mapping, i,
-                            self.eval_curve(mapping, 3, in_col.data[i]))
+                            self.eval_curve(mapping, 3, in_col.get_channel(i).data))
             for i in range(3)
-        ) + (in_col.data[3],)
+        ) + (in_col.get_channel(3).data,)
 
         return fac.blend(in_col, out_col)
 


### PR DESCRIPTION
### PURPOSE
Possible error in parsing ShaderNodeRGBCurve, more details #83.
`TypeError: 'float' object is not subscriptable`

### EFFECT OF CHANGE
Fixed possible error in parsing RGB Curve node.

### TECHNICAL STEPS
Fixed by using NodeItem.get_channel(), which works with float data value.
