### PR TITLE
RPRBLND-1476: Optimize Final render for RPR 2.0

### DIFF
--- a/src/bindings/pyrpr/src/pyrpr.py
+++ b/src/bindings/pyrpr/src/pyrpr.py
@@ -357,6 +357,9 @@ class Context(Object):
 
     def render(self):
         ContextRender(self)
+
+    def abort_render(self):
+        ContextAbortRender(self)
         
     def render_tile(self, xmin, xmax, ymin, ymax):
         ContextRenderTile(self, xmin, xmax, ymin, ymax)

--- a/src/bindings/pyrpr/src/pyrpr2.py
+++ b/src/bindings/pyrpr/src/pyrpr2.py
@@ -1,66 +1,97 @@
-import math
-import numpy as np
-
+# **********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
 import pyrpr
-from pyrprwrap import (
-    ContextCreateSphereLight,
-    SphereLightSetRadiantPower3f,
-    SphereLightSetRadius,
-    ContextCreateDiskLight,
-    DiskLightSetRadiantPower3f,
-    DiskLightSetRadius,
-    DiskLightSetAngle,
-)
 
 # will be used in other modules to check if RPR 2 is enabled
 enabled = False
 
 
 class Context(pyrpr.Context):
-    pass
+    def __init__(self, flags: [set, int], props: list = None, use_cache=True):
+        super().__init__(flags, props, use_cache)
+        self.render_update_callback = None
+
+    def set_render_update_callback(self, callback_func):
+        if callback_func:
+            @pyrpr.ffi.callback("void(float, void *)")
+            def render_update_callback(progress, data):
+                callback_func(progress)
+
+            pyrpr.ContextSetParameterByKeyPtr(self, pyrpr.CONTEXT_RENDER_UPDATE_CALLBACK_FUNC,
+                                              render_update_callback)
+            self.render_update_callback = render_update_callback
+
+        else:
+            pyrpr.ContextSetParameterByKeyPtr(self, pyrpr.CONTEXT_RENDER_UPDATE_CALLBACK_FUNC,
+                                              pyrpr.ffi.NULL)
+            self.render_update_callback = None
+
+    def delete(self):
+        self.set_render_update_callback(None)
+        super().delete()
 
 
 class SphereLight(pyrpr.Light):
     def __init__(self, context):
         super().__init__(context)
-        ContextCreateSphereLight(self.context, self)
+        pyrpr.ContextCreateSphereLight(self.context, self)
 
         # keep target intensity and radius to adjust actual intensity when they are changed
         self._radius_squared = 1
 
     def set_radiant_power(self, r, g, b):
         # Adjust intensity by current radius
-        SphereLightSetRadiantPower3f(self,
-                                     r / self._radius_squared,
-                                     g / self._radius_squared,
-                                     b / self._radius_squared)
+        pyrpr.SphereLightSetRadiantPower3f(self,
+                                           r / self._radius_squared,
+                                           g / self._radius_squared,
+                                           b / self._radius_squared)
 
     def set_radius(self, radius):
         radius = max(radius, 0.01)
         self._radius_squared = radius * radius
-        SphereLightSetRadius(self, radius)
+        pyrpr.SphereLightSetRadius(self, radius)
 
 
 class DiskLight(pyrpr.Light):
     def __init__(self, context):
         super().__init__(context)
-        ContextCreateDiskLight(self.context, self)
+        pyrpr.ContextCreateDiskLight(self.context, self)
 
         # keep target intensity and radius to adjust actual intensity when they are changed
         self._radius_squared = 1
 
     def set_radiant_power(self, r, g, b):
         # Adjust intensity by current radius
-        DiskLightSetRadiantPower3f(self,
+        pyrpr.DiskLightSetRadiantPower3f(self,
                                    r / self._radius_squared,
                                    g / self._radius_squared,
                                    b / self._radius_squared)
 
     def set_cone_shape(self, iangle, oangle):
         # Use external angle oangle
-        DiskLightSetAngle(self, oangle)
+        pyrpr.DiskLightSetAngle(self, oangle)
 
     def set_radius(self, radius):
         radius = max(radius, 0.01)
         self._radius_squared = radius * radius
-        DiskLightSetRadius(self, radius)
+        pyrpr.DiskLightSetRadius(self, radius)
+
+
+class PostEffect:
+    def __init__(self, context, post_effect_type):
+        pass
+
+    def set_parameter(self, name, param):
+        pass

--- a/src/rprblender/__init__.py
+++ b/src/rprblender/__init__.py
@@ -45,7 +45,8 @@ from . import (
     material_library,
 )
 
-from .engine.render_engine import RenderEngine, RenderEngine2
+from .engine.render_engine import RenderEngine
+from .engine.render_engine_2 import RenderEngine2
 from .engine.preview_engine import PreviewEngine
 from .engine.viewport_engine import ViewportEngine, ViewportEngine2
 from .engine.animation_engine import AnimationEngine, AnimationEngine2

--- a/src/rprblender/engine/animation_engine.py
+++ b/src/rprblender/engine/animation_engine.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-from .render_engine import RenderEngine, RenderEngine2
+from .render_engine import RenderEngine
+from .render_engine_2 import RenderEngine2
 
 
 class AnimationEngine(RenderEngine):

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -578,3 +578,6 @@ class RPRContext2(RPRContext):
                 obj.set_subdivision_factor(obj.subdivision['factor'])
                 obj.set_subdivision_boundary_interop(obj.subdivision['boundary'])
                 obj.set_subdivision_crease_weight(obj.subdivision['crease_weight'])
+
+    def set_render_update_callback(self, func):
+        self.context.set_render_update_callback(func)

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -129,6 +129,9 @@ class RPRContext:
         else:
             self.context.render_tile(*tile)
 
+    def abort_render(self):
+        self.context.abort_render()
+
     def get_image(self, aov_type=None):
         return self.get_frame_buffer(aov_type).get_data()
 

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #********************************************************************
 from abc import ABCMeta, abstractmethod
-import os
 
 import pyrpr
 import pyhybrid
@@ -35,7 +34,10 @@ class ImageFilter(metaclass=ABCMeta):
         # creating context
         creation_flags = rpr_context.get_creation_flags()
         if creation_flags & pyrpr.CREATION_FLAGS_ENABLE_METAL:
-            self.context = rif.ContextMetal(rpr_context)
+            if isinstance(rpr_context, pyrpr2.Context):
+                self.context = rif.Context(rpr_context)
+            else:
+                self.context = rif.ContextMetal(rpr_context)
         elif pyrpr.is_gpu_enabled(creation_flags) and \
                 not isinstance(rpr_context, (pyhybrid.Context, pyrpr2.Context)):
             self.context = rif.ContextOpenCL(rpr_context)

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -68,7 +68,8 @@ class RenderEngine(Engine):
 
     def notify_status(self, progress, info):
         """ Display export/render status """
-        self.rpr_engine.update_progress(progress)
+        if progress is not None:
+            self.rpr_engine.update_progress(progress)
         self.rpr_engine.update_stats(self.status_title, info)
 
     def _render(self):

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -68,8 +68,7 @@ class RenderEngine(Engine):
 
     def notify_status(self, progress, info):
         """ Display export/render status """
-        if progress is not None:
-            self.rpr_engine.update_progress(progress)
+        self.rpr_engine.update_progress(progress)
         self.rpr_engine.update_stats(self.status_title, info)
 
     def _render(self):

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -617,20 +617,3 @@ class RenderEngine(Engine):
                 p.rect = [e[:p.channels] for e in ordered_text_bytes]
 
             self.rpr_engine.end_result(result)
-
-
-from .context import RPRContext2
-
-
-class RenderEngine2(RenderEngine):
-    _RPRContext = RPRContext2
-
-    def _update_athena_data(self, data):
-        data['Quality'] = "rpr2"
-
-    def render_update_callback(self, progress):
-        print("render_update_callback", progress)
-
-    def _init_rpr_context(self, scene):
-        super()._init_rpr_context(scene)
-        self.rpr_context.set_render_update_callback(self.render_update_callback)

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -627,3 +627,10 @@ class RenderEngine2(RenderEngine):
 
     def _update_athena_data(self, data):
         data['Quality'] = "rpr2"
+
+    def render_update_callback(self, progress):
+        print("render_update_callback", progress)
+
+    def _init_rpr_context(self, scene):
+        super()._init_rpr_context(scene)
+        self.rpr_context.set_render_update_callback(self.render_update_callback)

--- a/src/rprblender/engine/render_engine_2.py
+++ b/src/rprblender/engine/render_engine_2.py
@@ -28,7 +28,7 @@ class RenderEngine2(RenderEngine):
     def _update_athena_data(self, data):
         data['Quality'] = "rpr2"
 
-    def render(self):
+    def _render(self):
         resolve_event = threading.Event()
         is_finished = False
         time_begin = 0.0
@@ -80,7 +80,7 @@ class RenderEngine2(RenderEngine):
 
         time_begin = time.perf_counter()
         try:
-            super().render()
+            super()._render()
 
         finally:
             is_finished = True

--- a/src/rprblender/engine/render_engine_2.py
+++ b/src/rprblender/engine/render_engine_2.py
@@ -1,0 +1,61 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import threading
+
+from rprblender import RenderEngine
+from rprblender.engine.context import RPRContext2
+
+from rprblender.utils import logging
+log = logging.Log(tag='RenderEngine2')
+
+
+class RenderEngine2(RenderEngine):
+    _RPRContext = RPRContext2
+
+    def _update_athena_data(self, data):
+        data['Quality'] = "rpr2"
+
+    def render(self):
+        resolve_event = threading.Event()
+        is_finished = False
+
+        def render_update_callback(progress):
+            resolve_event.set()
+
+        def do_resolve():
+            log('Start do_resolve')
+            while True:
+                resolve_event.wait()
+
+                if is_finished or self.rpr_engine.test_break():
+                    break
+
+                self.rpr_context.resolve()
+                self.update_render_result((0, 0), (self.width, self.height),
+                                          layer_name=self.render_layer_name)
+
+            log('Finish do_resolve')
+
+        self.rpr_context.set_render_update_callback(render_update_callback)
+        resolve_thread = threading.Thread(target=do_resolve)
+        resolve_thread.start()
+
+        try:
+            super().render()
+
+        finally:
+            is_finished = True
+            resolve_event.set()
+            resolve_thread.join()

--- a/src/rprblender/engine/render_engine_2.py
+++ b/src/rprblender/engine/render_engine_2.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #********************************************************************
 import threading
+import time
 
 from rprblender import RenderEngine
 from rprblender.engine.context import RPRContext2
@@ -30,14 +31,27 @@ class RenderEngine2(RenderEngine):
     def render(self):
         resolve_event = threading.Event()
         is_finished = False
+        time_begin = 0.0
 
         def render_update_callback(progress):
+            if progress == 1.0:
+                return
+
+            self.current_render_time = time.perf_counter() - time_begin
+            info_str = f"Render Time: {self.current_render_time:.1f}"
+            if self.render_time:
+                info_str += f"/{self.render_time}"
+            info_str += f" sec | Samples: {self.current_sample}/{self.render_samples}"
+            info_str += '.' * int(progress / 0.2)
+            self.notify_status(None, info_str)
+
             resolve_event.set()
 
         def do_resolve():
             log('Start do_resolve')
             while True:
                 resolve_event.wait()
+                resolve_event.clear()
 
                 if is_finished or self.rpr_engine.test_break():
                     break
@@ -52,6 +66,7 @@ class RenderEngine2(RenderEngine):
         resolve_thread = threading.Thread(target=do_resolve)
         resolve_thread.start()
 
+        time_begin = time.perf_counter()
         try:
             super().render()
 
@@ -59,3 +74,6 @@ class RenderEngine2(RenderEngine):
             is_finished = True
             resolve_event.set()
             resolve_thread.join()
+
+    def _render(self):
+        super()._render()

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -307,7 +307,7 @@ class RPR_RenderProperties(RPR_Properties):
 
     @property
     def is_tile_render_available(self):
-        return self.use_tile_render and self.render_quality in ('FULL', 'FULL2')
+        return self.use_tile_render and self.render_quality == 'FULL'
 
     # RAY DEPTH PROPERTIES
     use_clamp_radiance: BoolProperty(

--- a/src/rprblender/properties/view_layer.py
+++ b/src/rprblender/properties/view_layer.py
@@ -143,7 +143,7 @@ class RPR_DenoiserProperties(RPR_Properties):
         }
 
     def is_available(self, scene, is_final_engine=True):
-        return scene.rpr.render_quality != 'FULL2'
+        return True
 
 
 class RPR_ViewLayerProperites(RPR_Properties):

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -129,7 +129,7 @@ class RPR_RENDER_PT_limits(RPR_Panel):
         col.prop(limits, 'seconds')
 
         col = self.layout.column(align=True)
-        col.enabled = rpr.render_quality in ('FULL', 'FULL2')
+        col.enabled = rpr.render_quality == 'FULL'
         col.prop(rpr, 'use_tile_render')
 
         col = col.column(align=True)


### PR DESCRIPTION
### PURPOSE
RPR 2.0 provides features with update render callback to get intermediate render results during ContextRender and more optimized when using bigger iteration parameter.

### EFFECT OF CHANGE
Provided new more optimized final rendering algorithm for RPR 2.0.
Disabled tile rendering for RPR 2.0, as it works by tiles internally.
Enabled denoising for RPR 2.0 in final render.

### TECHNICAL STEPS
1. In pyrpr wrappers:
- added pyrpr2.Context.set_render_update_callback() function to set the callback
- added pyrpr.Context.abort_render()
- set empty PostEffect for pyrpr2
- code improvement in pyrpr2
2. Moved RenderEngine2 into render_engine_2.py. Done there:
- made _render() function to update intermediate render results in separate thread after receiving render update callback.
3. Disabled tile rendering for RPR 2.0 in UI.
4. Enabled denoiser for RPR 2.0 and fixed it in MacOS.
