### PR TITLE
RPRBLND-1416: Enable viewport denoising

### DIFF
--- a/src/rprblender/engine/viewport_engine_2.py
+++ b/src/rprblender/engine/viewport_engine_2.py
@@ -40,9 +40,9 @@ class ViewportEngine2(ViewportEngine):
 
         self.resolve_event = threading.Event()
         self.resolve_thread = None
+        self.resolve_lock = threading.Lock()
 
     def stop_render(self):
-        self.is_abort_render = True
         super().stop_render()
 
         self.resolve_event.set()
@@ -217,9 +217,6 @@ class ViewportEngine2(ViewportEngine):
         im = self.rendered_image
         if im is None:
             return
-
-        if self.gl_texture.width != im.shape[1] or self.gl_texture.height != im.shape[0]:
-            self.gl_texture = gl.GLTexture(im.shape[1], im.shape[0])
 
         self.gl_texture.set_image(im)
         self.draw_texture(self.gl_texture.texture_id, context.scene)


### PR DESCRIPTION
### PURPOSE
Denoiser in viewport only at last iteration isn't enough, would be good to see denoiser results at intermediate iterations.

### EFFECT OF CHANGE
Applied denoising in viewport at 4, 8, 16, 32, 64, 96, 128... iterations, not only at last iteration. Increased viewport speed.

### TECHNICAL STEPS
1. Applied denoising in viewport at 4, 8, 16, 32, 64, 96, 128... iterations.
2. Improved GLTexture, now it holds image pixels and can be resized during set_image().
3. Increased viewport speed by: 
    - with enabled denosier: denosied image is prepared once and is used to draw without getting data from image filter + resolve context doesn't called
    - with disabled denoiser: resolve context is called in draw() so it could be called not every iteration.

### NOTES FOR REVIEWERS
Denoising is applied in the same thread were rendering is applied. Due to denoiser is applied only at 4, 8, 16, 32, 64, 96, 128... iterations it doesn't so noticeable especially on heavy scenes.
I tried several approaches and did lot of investigation of were denosier should be applied: 
1. In render thread - most stable and simple algorithm. Decided to use this.
2. In separate denoiser thread - slightly faster then 1) but less stable during resizing and other scene updates.
3. In draw() method - quite stable but could hung viewport, speed is same as 1).