### PR TITLE
Rename blender 28x exe build variable.

### DIFF
--- a/README-OSX.md
+++ b/README-OSX.md
@@ -60,10 +60,10 @@ NOTES:
 
 ### Running
 
-Ensure that the BLENDER_28X_EXE environment variable is set.  For example, add the following to
+Ensure that the BLENDER_EXE environment variable is set.  For example, add the following to
 your ~/.profile with the correct path to the Blender executable:
 
-    export BLENDER_28X_EXE="/Users/amd/Downloads/blender-2.78c-OSX_10.6-x86_64/blender.app/Contents/MacOS/blender"
+    export BLENDER_EXE="/Users/amd/Downloads/blender-2.78c-OSX_10.6-x86_64/blender.app/Contents/MacOS/blender"
 
 To run the local build, use:
 	- ./run_blender_with_rpr_osx.sh

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ run `build.py` to build.
 ## Run Addon while developing it(without real installation)
 
 - make sure you have no installed addon for Blender version you want to use; remove installed version if needed.
-- set environment variable BLENDER_28x_EXE to blender.exe you want to use via the command line or system environment settings.
+- set environment variable BLENDER_EXE to blender.exe you want to use via the command line or system environment settings.
 - run run_blender_with_rpr.cmd
 
 Example:
 
-`set BLENDER_28X_EXE="C:\Program Files\Blender Foundation\Blender 2.81\blender.exe" && run_blender_with_rpr.cmd`
+`set BLENDER_EXE="C:\Program Files\Blender Foundation\Blender 2.81\blender.exe" && run_blender_with_rpr.cmd`
 
 ### Debugging
 

--- a/run_blender_with_rpr.cmd
+++ b/run_blender_with_rpr.cmd
@@ -17,12 +17,12 @@ REM  *******************************************************************
 
 @echo on
 
-if ""=="%BLENDER_28x_EXE%" goto error
+if ""=="%BLENDER_EXE%" goto error
 
-py cmd_tools/run_blender.py "%BLENDER_28x_EXE%" cmd_tools/test_rpr.py
+py cmd_tools/run_blender.py "%BLENDER_EXE%" cmd_tools/test_rpr.py
 pause
 REM it's much easier to get issue traceback on crash if pause is present; remove if not needed
 exit
 
 :error
-echo "Please set BLENDER_28x_EXE environment variable"
+echo "Please set BLENDER_EXE environment variable"

--- a/run_blender_with_rpr_Ubuntu.sh
+++ b/run_blender_with_rpr_Ubuntu.sh
@@ -29,8 +29,8 @@ GLTF_LIBNAME="libProRenderGLTF.so"
 
 function init()
 {
-	if [ ! -x "$BLENDER_28x_EXE" ]; then
-		echo "Could not find blender application. Please, specify BLENDER_28x_EXE environment variable"
+	if [ ! -x "$BLENDER_EXE" ]; then
+		echo "Could not find blender application. Please, specify BLENDER_EXE environment variable"
 		exit 1
 	fi
 
@@ -67,7 +67,7 @@ function main()
 
 	export LD_LIBRARY_PATH="$WORK_DIR:$LD_LIBRARY_PATH"
 
-	python3 cmd_tools/run_blender.py "$BLENDER_28x_EXE" cmd_tools/test_rpr.py
+	python3 cmd_tools/run_blender.py "$BLENDER_EXE" cmd_tools/test_rpr.py
 
 }
 

--- a/run_blender_with_rpr_osx.sh
+++ b/run_blender_with_rpr_osx.sh
@@ -15,11 +15,11 @@
 # limitations under the License.
 #********************************************************************
 
-echo BLENDER_28x_EXE "${BLENDER_28x_EXE}"
+echo BLENDER_EXE "${BLENDER_EXE}"
 
 DEBUGGER_EXE="$1"
 
-if [ -x "${BLENDER_28x_EXE}" ]; then
+if [ -x "${BLENDER_EXE}" ]; then
 	rm -rf dist/
 	mkdir dist
 	cp -r .sdk/rpr/bin dist/
@@ -32,7 +32,7 @@ if [ -x "${BLENDER_28x_EXE}" ]; then
 
 	export LD_LIBRARY_PATH="$DIST_LIB"
 
-	python3 cmd_tools/run_blender.py "$BLENDER_28x_EXE" cmd_tools/test_rpr.py "$DEBUGGER_EXE"
+	python3 cmd_tools/run_blender.py "$BLENDER_EXE" cmd_tools/test_rpr.py "$DEBUGGER_EXE"
 
 	rm distlib
 


### PR DESCRIPTION
### PURPOSE
Rename build methods using BLENDER_28x_EXE to BLENDER_EXE.  Since we can now build with 2.90 etc.

### EFFECT OF CHANGE
No functional change

### TECHNICAL STEPS
DEVELOPERS build scripts may need to be updated