### PR TITLE
RPRBLND-1490: Hybrid causes ContextSetAOVindexLookup to return CoreError

### DIFF
--- a/src/bindings/pyrpr/src/pyhybrid.py
+++ b/src/bindings/pyrpr/src/pyhybrid.py
@@ -31,7 +31,8 @@ def ignore_unsupported(function):
             return function(*args, **kwargs)
 
         except pyrpr.CoreError as e:
-            if e.status not in (pyrpr.ERROR_UNSUPPORTED, pyrpr.ERROR_INVALID_PARAMETER):
+            if e.status not in (pyrpr.ERROR_UNSUPPORTED, pyrpr.ERROR_INVALID_PARAMETER,
+                                pyrpr.ERROR_UNIMPLEMENTED):
                 raise
 
             if hybrid_unsupported_log_warn:
@@ -80,6 +81,10 @@ class Context(pyrpr.Context):
     @ignore_unsupported
     def detach_aov(self, aov):
         super().detach_aov(aov)
+
+    @ignore_unsupported
+    def set_aov_index_lookup(self, key, r, g, b, a):
+        super().set_aov_index_lookup(key, r, g, b, a)
 
 
 @class_ignore_unsupported


### PR DESCRIPTION
### PURPOSE
PR #95 produced error in Hybrid, because ContextSetAOVindexLookup produces ERROR_UNIMPLEMENTED exception.

### EFFECT OF CHANGE
Fixed Hybrid rendering after PR #95.

### TECHNICAL STEPS
- Added ERROR_UNIMPLEMENTED to ignore_unsupported attribute.
- Added ignore_unsupported attribute to pyhybrid.Context.set_aov_index_lookup()
