### PR TITLE
RPRBLND-1520: Move to use Direct transform setting for motion blur

### DIFF
--- a/src/bindings/pyrpr/src/pyrpr2.py
+++ b/src/bindings/pyrpr/src/pyrpr2.py
@@ -39,6 +39,25 @@ class Context(pyrpr.Context):
             self.render_update_callback = None
 
 
+class Shape(pyrpr.Shape):
+    def set_motion_transform(self, transform, transpose=True): # Blender needs matrix to be transposed
+        pyrpr.ShapeSetMotionTransformCount(self, 1)
+        pyrpr.ShapeSetMotionTransform(self, transpose, pyrpr.ffi.cast('float*', transform.ctypes.data), 1)
+
+
+class Mesh(pyrpr.Mesh, Shape):
+    pass
+
+
+class Instance(pyrpr.Instance, Shape):
+    pass
+
+
+class AreaLight(pyrpr.AreaLight):
+    def set_motion_transform(self, transform, transpose=True): # Blender needs matrix to be transposed
+        self.mesh.set_motion_transform(transform, transpose)
+
+
 class SphereLight(pyrpr.Light):
     def __init__(self, context):
         super().__init__(context)

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -36,7 +36,6 @@ class RPRContext:
     _EnvironmentLight = pyrpr.EnvironmentLight
 
     _Camera = pyrpr.Camera
-    _Shape = pyrpr.Shape
     _Mesh = pyrpr.Mesh
     _Instance = pyrpr.Instance
     _Curve = pyrpr.Curve
@@ -560,6 +559,11 @@ class RPRContext2(RPRContext):
 
     # Classes
     _Context = pyrpr2.Context
+
+    _Mesh = pyrpr2.Mesh
+    _Instance = pyrpr2.Instance
+
+    _AreaLight = pyrpr2.AreaLight
     _SphereLight = pyrpr2.SphereLight
     _DiskLight = pyrpr2.DiskLight
     _PostEffect = pyrpr2.PostEffect

--- a/src/rprblender/export/particle.py
+++ b/src/rprblender/export/particle.py
@@ -101,8 +101,14 @@ def sync(rpr_context, emitter: bpy.types.Object):
 
             # do motion blur.
             if rpr_context.do_motion_blur:
-                velocity = (particle.location[i] - particle.prev_location[i] for i in range(3))
-                instance.set_linear_motion(*velocity)
+                if hasattr(instance, 'set_motion_transform'):
+                    prev_loc = mathutils.Matrix.Translation(particle.prev_location)
+                    prev_mat = np.array(prev_loc @ rot.to_matrix().to_4x4() @ scale, dtype=np.float32)\
+                        .reshape(4, 4)
+                    instance.set_motion_transform(prev_mat)
+                else:
+                    velocity = (particle.location[i] - particle.prev_location[i] for i in range(3))
+                    instance.set_linear_motion(*velocity)
 
                 # TODO angular motion doesn't work right.
                 #rotation = (particle.rotation[i] - particle.prev_rotation[i] for i in range(4))


### PR DESCRIPTION
### PURPOSE
Motion blur functionality for RPR 2.0 was integrated in new core with rprShapeSetMotionTransform() and rprShapeSetMotionTransformCount() functions. 

### EFFECT OF CHANGE
Implemented motion blur for RPR 2.0.

### TECHNICAL STEPS
- Implemented pyrpr2.Shape.set_motion_transform(), pyrpr2.AreaLight.set_motion_transform().
- Adjusted Engine.sync_motion_blur() and particle.sync() to use new functionality.

### NOTES FOR REVIEWERS
RPR 1 still uses old functionality.