### PR TITLE
Render mode in final render

### DIFF
--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -469,6 +469,7 @@ class RenderEngine(Engine):
 
         # SET rpr_context parameters
         self.rpr_context.set_parameter(pyrpr.CONTEXT_PREVIEW, False)
+        scene.rpr.export_render_mode(self.rpr_context)
         scene.rpr.export_ray_depth(self.rpr_context)
         scene.rpr.export_pixel_filter(self.rpr_context)
 

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -190,8 +190,10 @@ class RPR_RENDER_PT_quality(RPR_Panel):
 
         rpr = context.scene.rpr
 
-        if len(rpr.render_quality_items) > 1:
-            self.layout.prop(rpr, 'render_quality')
+        self.layout.prop(rpr, 'render_quality')
+        row = self.layout.row()
+        row.enabled = rpr.render_quality in ('FULL', 'FULL2')
+        row.prop(rpr, 'render_mode')
 
 
 class RPR_RENDER_PT_max_ray_depth(RPR_Panel):

--- a/src/rprblender/ui/view3d.py
+++ b/src/rprblender/ui/view3d.py
@@ -37,10 +37,10 @@ class RPR_VIEW3D_PT_panel(RPR_Panel):
 
         rpr = context.scene.rpr
 
-        if len(rpr.render_quality_items) > 1:
-            layout.prop(rpr, 'render_quality')
-
-        layout.prop(rpr, 'render_mode')
+        layout.prop(rpr, 'render_quality')
+        row = layout.row()
+        row.enabled = rpr.render_quality in ('FULL', 'FULL2')
+        row.prop(rpr, 'render_mode')
 
 
 def draw_menu(self, context):


### PR DESCRIPTION
### PURPOSE
Render Mode option can be added for final render too.

### EFFECT OF CHANGE
Added Render Mode option to final render, updated UI by disabling it for hybrid, as not supported.

### TECHNICAL STEPS
- added scene.rpr.export_render_mode to final render sync()
- updated ui/render.py and ui.view3d.py with render_mode option which is disabled for hybrid.
