### PR TITLE
Set zip compression level to Z_BEST_COMPRESSION in create_zip_addon.py.

### DIFF
--- a/BlenderPkg/create_zip_addon.py
+++ b/BlenderPkg/create_zip_addon.py
@@ -14,6 +14,7 @@
 #********************************************************************
 
 import zipfile
+import zlib
 import platform
 from pathlib import Path
 import subprocess
@@ -93,7 +94,8 @@ def create_zip_addon(build_dir):
     zip_addon = build_dir / f"rprblender-{ver[0]}.{ver[1]}.{ver[2]}-{ver[3]}-{OS.lower()}.zip"
 
     print(f"Compressing addon files to: {zip_addon}")
-    with zipfile.ZipFile(zip_addon, 'w') as myzip:
+    with zipfile.ZipFile(zip_addon, 'w', compression=zipfile.ZIP_DEFLATED,
+                         compresslevel=zlib.Z_BEST_COMPRESSION) as myzip:
         for src, package_path in enumerate_addon_data():
             print(f"adding {src} --> {package_path}")
 


### PR DESCRIPTION
### PURPOSE
We didn't use any zip compression level for zipping plugin installer. Therefore size of plugin took 166MB in Windows. With zip compression the size decreases to 103 MB.

### EFFECT OF CHANGE
Decreased zip installer plugin size by 40% approximately.

### TECHNICAL STEPS
Set compression=zipfile.ZIP_DEFLATED and compresslevel=zlib.Z_BEST_COMPRESSION in creating ZipFile.