### PR TITLE
RPRBLND-1502: Memory leak with specific scene

### DIFF
--- a/src/bindings/pyrpr/src/pyhybrid.py
+++ b/src/bindings/pyrpr/src/pyhybrid.py
@@ -143,6 +143,10 @@ class MaterialNode(pyrpr.MaterialNode):
 
         super().set_input(name, value)
 
+    def delete(self):
+        self.inputs.clear()
+        super().delete()
+
 
 class EmptyMaterialNode(MaterialNode):
     def __init__(self, material_type):

--- a/src/bindings/pyrpr/src/pyrpr.py
+++ b/src/bindings/pyrpr/src/pyrpr.py
@@ -232,9 +232,8 @@ class array:
 class Object:
     core_type_name = 'void*'
 
-    def __init__(self, core_type_name=None):
-        self.ffi_type_name = (core_type_name if core_type_name is not None else self.core_type_name) + '*'
-        self._reset_handle()
+    def __init__(self):
+        self._handle_ptr = ffi.new(self.core_type_name + '*', ffi.NULL)
         self.name = None
 
     def __del__(self):
@@ -244,14 +243,13 @@ class Object:
             _init_data._log_fun('EXCEPTION:', traceback.format_exc())
 
     def delete(self):
-        if self._handle_ptr and self._get_handle():
-            if lib_wrapped_log_calls:
-                _init_data._log_fun('delete: ', self.name, self)
-            ObjectDelete(self._get_handle())
-            self._reset_handle()
+        if lib_wrapped_log_calls:
+            _init_data._log_fun('delete: ', self.name, self)
 
-    def _reset_handle(self):
-        self._handle_ptr = ffi.new(self.ffi_type_name, ffi.NULL)
+        if self._get_handle():
+            ObjectDelete(self._get_handle())
+
+        ffi.release(self._handle_ptr)
 
     def _get_handle(self):
         return self._handle_ptr[0]
@@ -1171,6 +1169,18 @@ class MaterialNode(Object):
         self.inputs = {}
         self.type = material_type
         MaterialSystemCreateNode(self.material_system, self.type, self)
+
+    def delete(self):
+        for name, value in self.inputs.items():
+            if isinstance(value, MaterialNode):
+                MaterialNodeSetInputNByKey(self, name, None)
+            elif isinstance(value, Image):
+                MaterialNodeSetInputImageDataByKey(self, name, None)
+            elif isinstance(value, Buffer):
+                MaterialNodeSetInputBufferDataByKey(self, name, None)
+        self.inputs.clear()
+
+        super().delete()
 
     def set_input(self, name, value):
         if isinstance(value, MaterialNode):


### PR DESCRIPTION
### PURPOSE
This is an old bug (from beginning), which is reproducible on scenes which have material with lot of arithmetic. Memory leak especially noticeable during animation render.

### EFFECT OF CHANGE
Fixed memory leak during rendering some scenes, which was especially noticeable during animation render.

### TECHNICAL STEPS
Done:
- added pyrpr.MaterialNode.delete() which removes all links from material node and deletes node more correctly;
- adjusted pyhybrid.MaterialNode.delete() which just removes links;
- small cleanup in pyrpr.Object.