### PR TITLE
Fixing possible AttributeError

### DIFF
--- a/src/bindings/pyrpr/src/pyrpr.py
+++ b/src/bindings/pyrpr/src/pyrpr.py
@@ -249,8 +249,6 @@ class Object:
         if self._get_handle():
             ObjectDelete(self._get_handle())
 
-        ffi.release(self._handle_ptr)
-
     def _get_handle(self):
         return self._handle_ptr[0]
 


### PR DESCRIPTION
### PURPOSE
Possible error after #122: AttributeError:  'CompiledFFI' object has no attribute 'release'

### TECHNICAL STEPS
Removed ffi.release() as not necessary.