### PR TITLE
RPRBLND-1538: Low subdivision level causes a system crash.

### DIFF
--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -329,8 +329,7 @@ class RPRContext:
             fb = pyrpr.FrameBuffer(self.context, width, height)
 
         for obj in objects_with_adaptive_subdivision:
-            factor = obj.subdivision['factor'] - 8  # adjusting subdivision factor to RPR 2
-            obj.set_auto_adapt_subdivision_factor(fb, camera, factor)
+            obj.set_auto_adapt_subdivision_factor(fb, camera, obj.subdivision['factor'])
             obj.set_subdivision_boundary_interop(obj.subdivision['boundary'])
             obj.set_subdivision_crease_weight(obj.subdivision['crease_weight'])
 
@@ -592,8 +591,7 @@ class RPRContext2(RPRContext):
         auto_ratio_cap = 1.0 / height
 
         for obj in objects_with_adaptive_subdivision:
-            factor = max(obj.subdivision['factor'], 0)
-            obj.set_subdivision_factor(factor)
+            obj.set_subdivision_factor(obj.subdivision['level'])
             obj.set_subdivision_auto_ratio_cap(auto_ratio_cap)
             obj.set_subdivision_boundary_interop(obj.subdivision['boundary'])
             obj.set_subdivision_crease_weight(obj.subdivision['crease_weight'])

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -318,7 +318,7 @@ class RPRContext:
         if height == 0:
             height = self.height
 
-        objects_with_adaptive_subdivision = self.get_adaptive_subdivision_objects()
+        objects_with_adaptive_subdivision = self._get_adaptive_subdivision_objects()
 
         if not objects_with_adaptive_subdivision:
             return
@@ -328,21 +328,15 @@ class RPRContext:
             # creating temporary FrameBuffer of required size only to set subdivision
             fb = pyrpr.FrameBuffer(self.context, width, height)
 
-        self.set_subdivision_on_objects(camera, fb, objects_with_adaptive_subdivision)
-
-    def get_adaptive_subdivision_objects(self):
-        objects_with_adaptive_subdivision = tuple(
-            obj for obj in self.scene.objects
-            if isinstance(obj, pyrpr.Shape) and obj.subdivision is not None
-        )
-        return objects_with_adaptive_subdivision
-
-    def set_subdivision_on_objects(self, camera, subdivision_framebuffer, objects):
-        """ Apply subdivision to objects using context-specific methods """
-        for obj in objects:
-            obj.set_auto_adapt_subdivision_factor(subdivision_framebuffer, camera, obj.subdivision['factor'])
+        for obj in objects_with_adaptive_subdivision:
+            factor = obj.subdivision['factor'] - 8  # adjusting subdivision factor to RPR 2
+            obj.set_auto_adapt_subdivision_factor(fb, camera, factor)
             obj.set_subdivision_boundary_interop(obj.subdivision['boundary'])
             obj.set_subdivision_crease_weight(obj.subdivision['crease_weight'])
+
+    def _get_adaptive_subdivision_objects(self):
+        return tuple(obj for obj in self.scene.objects
+                     if isinstance(obj, pyrpr.Shape) and obj.subdivision is not None)
 
     def sync_portal_lights(self):
         """ Attach active Portal Light objects to active environment light """
@@ -591,16 +585,14 @@ class RPRContext2(RPRContext):
         if height == 0:
             height = self.height
 
-        objects_with_adaptive_subdivision = self.get_adaptive_subdivision_objects()
-
-        if not objects_with_adaptive_subdivision or height == 0:
+        objects_with_adaptive_subdivision = self._get_adaptive_subdivision_objects()
+        if not objects_with_adaptive_subdivision:
             return
 
         auto_ratio_cap = 1.0 / height
 
         for obj in objects_with_adaptive_subdivision:
             factor = max(obj.subdivision['factor'], 0)
-
             obj.set_subdivision_factor(factor)
             obj.set_subdivision_auto_ratio_cap(auto_ratio_cap)
             obj.set_subdivision_boundary_interop(obj.subdivision['boundary'])

--- a/src/rprblender/engine/export_engine.py
+++ b/src/rprblender/engine/export_engine.py
@@ -86,7 +86,7 @@ class ExportEngine(Engine):
 
         # adaptive subdivision will be limited to the current scene render size
         self.rpr_context.enable_aov(pyrpr.AOV_COLOR)
-        self.rpr_context.sync_auto_adapt_subdivision(self.rpr_context.width, self.rpr_context.height)
+        self.rpr_context.sync_auto_adapt_subdivision()
 
         self.rpr_context.sync_portal_lights()
 

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -303,7 +303,7 @@ class RenderEngine(Engine):
         if not self.is_synced:
             return
 
-        self.rpr_context.sync_auto_adapt_subdivision(self.width, self.height)
+        self.rpr_context.sync_auto_adapt_subdivision()
         self.rpr_context.sync_portal_lights()
 
         log(f"Start render [{self.width}, {self.height}]")

--- a/src/rprblender/properties/object.py
+++ b/src/rprblender/properties/object.py
@@ -96,7 +96,7 @@ class RPR_ObjectProperites(RPR_Properties):
         name="Level",
         description="Subdivision level for mesh. For finer subdivision set upper",
         min=0, max=12, soft_max=8,
-        default=1
+        default=3
     )
     subdivision_boundary_type: EnumProperty(
         name="Boundary Type",

--- a/src/rprblender/properties/object.py
+++ b/src/rprblender/properties/object.py
@@ -92,9 +92,16 @@ class RPR_ObjectProperites(RPR_Properties):
         description="Enable subdivision",
         default=False,
     )
-    subdivision_factor: IntProperty(
+    subdivision_factor: FloatProperty(
+        name="Polygon Size",
+        description="Subdivision polygon size, in pixels that it should be subdivided to.\n"
+                    "For finer subdivision set lower.",
+        min=0.5, soft_max=512.0,
+        default=16.0
+    )
+    subdivision_level: IntProperty(
         name="Level",
-        description="Subdivision level for mesh. For finer subdivision set upper",
+        description="Subdivision level for mesh. For finer subdivision set upper.",
         min=0, max=12, soft_max=8,
         default=3
     )
@@ -133,8 +140,15 @@ class RPR_ObjectProperites(RPR_Properties):
     def export_subdivision(self, rpr_shape):
         """ Exports subdivision settings """
         if self.subdivision:
+            # convert factor from size of subdivision in pixel to RPR
+            # RPR wants the subdivision factor as the "number of faces per pixel"
+            # the setting gives user the size of face in number pixels.
+            # rpr internally does: subdivision size in pixel = 2^factor  / 16.0
+            factor = int(math.log2(16.0 / self.subdivision_factor))
+
             rpr_shape.subdivision = {
-                'factor': self.subdivision_factor,
+                'factor': factor,
+                'level': self.subdivision_level,
                 'boundary': pyrpr.SUBDIV_BOUNDARY_INTERFOP_TYPE_EDGE_AND_CORNER if self.subdivision_boundary_type == 'EDGE_CORNER' else
                 pyrpr.SUBDIV_BOUNDARY_INTERFOP_TYPE_EDGE_ONLY,
                 'crease_weight': self.subdivision_crease_weight

--- a/src/rprblender/properties/object.py
+++ b/src/rprblender/properties/object.py
@@ -93,7 +93,7 @@ class RPR_ObjectProperites(RPR_Properties):
         default=False,
     )
     subdivision_factor: FloatProperty(
-        name="Polygon Size",
+        name="Subdiv Polygon Size",
         description="Subdivision polygon size, in pixels that it should be subdivided to.\n"
                     "For finer subdivision set lower.",
         min=0.5, soft_max=512.0,

--- a/src/rprblender/properties/object.py
+++ b/src/rprblender/properties/object.py
@@ -92,11 +92,11 @@ class RPR_ObjectProperites(RPR_Properties):
         description="Enable subdivision",
         default=False,
     )
-    subdivision_factor: FloatProperty(
-        name="Adaptive Level",
-        description="Subdivision factor for mesh, in pixels that it should be subdivided to. For finer subdivision set lower.",
-        min=0.01, soft_max=10.0,
-        default=1.0
+    subdivision_factor: IntProperty(
+        name="Level",
+        description="Subdivision level for mesh. For finer subdivision set upper",
+        min=0, max=12, soft_max=8,
+        default=1
     )
     subdivision_boundary_type: EnumProperty(
         name="Boundary Type",
@@ -132,20 +132,15 @@ class RPR_ObjectProperites(RPR_Properties):
 
     def export_subdivision(self, rpr_shape):
         """ Exports subdivision settings """
-
         if self.subdivision:
-            # convert factor from size of subdivision in pixel to RPR
-            # RPR wants the subdivision factor as the "number of faces per pixel"
-            # the setting gives user the size of face in number pixels.
-            # rpr internally does: subdivision size in pixel = 2^factor  / 16.0
-            factor = int(math.log2(16.0 / self.subdivision_factor))
-            
             rpr_shape.subdivision = {
-                'factor': factor,
+                'factor': self.subdivision_factor,
                 'boundary': pyrpr.SUBDIV_BOUNDARY_INTERFOP_TYPE_EDGE_AND_CORNER if self.subdivision_boundary_type == 'EDGE_CORNER' else
                 pyrpr.SUBDIV_BOUNDARY_INTERFOP_TYPE_EDGE_ONLY,
                 'crease_weight': self.subdivision_crease_weight
             }
+        else:
+            rpr_shape.subdivision = None
 
     @classmethod
     def register(cls):

--- a/src/rprblender/ui/object.py
+++ b/src/rprblender/ui/object.py
@@ -63,7 +63,9 @@ class RPR_OBJECT_PT_subdivision(RPR_Panel):
     bl_parent_id = 'RPR_OBJECT_PT_object'
 
     def draw_header(self, context):
-        self.layout.prop(context.object.rpr, 'subdivision', text="")
+        row = self.layout.row()
+        row.enabled = context.scene.rpr.render_quality in ('FULL', 'FULL2')
+        row.prop(context.object.rpr, 'subdivision', text="")
 
     def draw(self, context):
         self.layout.use_property_split = True
@@ -72,9 +74,9 @@ class RPR_OBJECT_PT_subdivision(RPR_Panel):
         rpr = context.object.rpr
 
         col = self.layout.column()
-        col.enabled = rpr.subdivision
+        col.enabled = rpr.subdivision and context.scene.rpr.render_quality in ('FULL', 'FULL2')
         if context.scene.rpr.render_quality == 'FULL2':
-            col.prop(rpr, 'subdivision_factor', text="Level")
+            col.prop(rpr, 'subdivision_level')
         else:
             col.prop(rpr, 'subdivision_factor')
         col.prop(rpr, 'subdivision_crease_weight')


### PR DESCRIPTION
### PURPOSE
There are several issues in subdivision settings:
- low subdivision level causes a system crash;
- default subdivision level as 1.0 subdivides mesh so much, which to noticeably slows whole rendering;
- have several blames about misunderstanding of what subdivision level means and why it has values from 0.01 to 10.0 (soft max);
- RPR1 and RPR2 produce so different mesh subdivision in the same subdivision level.

### EFFECT OF CHANGE
Improved working with subdivision settings: changed behavior of subdivision level as integer value from 0 to 8 (as soft max) and 12 (as max).

### TECHNICAL STEPS
- changed behavior of subdivision level as integer value from 0 to 8 (as soft max) and 12 (as max)
- adjusted levels between RPR 1 and RPR 2
- made some code improvements

