### PR TITLE
RPRBLND-1555: Viewport 'preview' rendering produces square artifacts at next iterations

### DIFF
--- a/src/rprblender/engine/viewport_engine_2.py
+++ b/src/rprblender/engine/viewport_engine_2.py
@@ -60,6 +60,9 @@ class ViewportEngine2(ViewportEngine):
                 self.rpr_context.abort_render()
                 return
 
+            if iteration == 1:
+                return
+
             # don't need to do intermediate update for 0, 1 iteration and
             # at render finish when progress == 1.0
             if progress == 1.0:
@@ -134,6 +137,7 @@ class ViewportEngine2(ViewportEngine):
                     self.rpr_context.set_render_update_callback(None)
                     self.rpr_context.set_parameter(pyrpr.CONTEXT_PREVIEW, 3)
                 elif iteration == 1:
+                    self.rpr_context.clear_frame_buffers()
                     self.rpr_context.set_render_update_callback(render_update)
                     self.rpr_context.set_parameter(pyrpr.CONTEXT_PREVIEW, 0)
 


### PR DESCRIPTION
### PURPOSE
Using 'preview' rendering mode in viewport produces square artifacts at next iterations.

### EFFECT OF CHANGE
Fixed viewport rendering artifacts after using 'preview' rendering mode.

### TECHNICAL STEPS
Fixed by clearing framebuffers before second iteration disabling intermediate update at second iteration.