### PR TITLE
Use core 2.01.8.1 beta1

### DIFF
--- a/src/rprblender/__init__.py
+++ b/src/rprblender/__init__.py
@@ -20,7 +20,7 @@ import bpy
 bl_info = {
     "name": "Radeon ProRender",
     "author": "AMD",
-    "version": (3, 0, 1),
+    "version": (3, 0, 2),
     "blender": (2, 80, 0),
     "location": "Info header, render engine menu",
     "description": "Radeon ProRender rendering plugin for Blender 2.8x",


### PR DESCRIPTION
### PURPOSE
Wrong binaries were used during merge of develop to master. Provide correct core 2.01.8.1 beta 1 binaries.

### EFFECT OF CHANGE
- used correct SDK binaries - 2.01.8.1 beta 1.

### TECHNICAL STEPS
- switched submodule to latest SDK branch 2.01.8.1 beta 1 version.