### PR TITLE
PRBLND-1626: Fix MacOS build on CIS after applying OpenMP.

### DIFF
--- a/RPRBlenderHelper/CMakeLists.txt
+++ b/RPRBlenderHelper/CMakeLists.txt
@@ -5,18 +5,6 @@ project(RPRBlenderHelper)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 11)
 
-find_package(OpenMP REQUIRED)
-
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-else()
-    if(NOT "${IGNORE_MISSING_OPENMP}")
-        message(FATAL_ERROR "OpenMP support not found! Use IGNORE_MISSING_OPENMP=ON to override.")
-    endif() 
-endif()
-
-
 set(RPR_SDK_DIR ${CMAKE_SOURCE_DIR}/../.sdk/rpr)
 set(RPRTOOLS_DIR ${RPR_SDK_DIR}/rprTools)
 set(SHARED_DIR ${CMAKE_SOURCE_DIR}/../RadeonProRenderSharedComponents)
@@ -70,10 +58,9 @@ elseif(${APPLE})
         ${OPENVDB_SDK_PATH}/OSX/lib/libsnappy.a
         ${OPENVDB_SDK_PATH}/OSX/lib/libboost_iostreams.a
         ${OPENVDB_SDK_PATH}/OSX/lib/libtbb.a
-        ${OpenMP_CXX_LIBRARIES}
     )
 
-else()
+else()  # Linux
     set(LIBS ${RPR_SDK_DIR}/bin/libRadeonProRender64.so)
 
 endif()


### PR DESCRIPTION
### PURPOSE
PR #168 produces build error on our CIS machines with MacOS, because of required usage of OpenMP for RPRBlenederHelper app. But OpenMP is never used there (probably it was used there long time ago in 1.* plugin) and can be removed.

### TECHNICAL STEPS
Removed OpenMP usage from RPRBlenderHelper as not needed.