### PR TITLE
RPRBLND-1629: Issue with UDIM tiles

### DIFF
--- a/src/rprblender/export/image.py
+++ b/src/rprblender/export/image.py
@@ -82,7 +82,7 @@ def sync(rpr_context, image: bpy.types.Image, use_color_space=None, frame_number
                 tile_key = key(image, color_space, UDIM_tile=tile.label)
 
                 tile_image = rpr_context.create_image_file(tile_key, tile_path)
-                set_image_gamma(tile_image, image, color_space)
+                set_image_gamma(tile_image, image, color_space, rpr_context)
                 tile_image.set_name(str(tile_key))
 
                 rpr_image.set_udim_tile(tile.number, tile_image)


### PR DESCRIPTION
### PURPOSE
Using UDIM tiles could produce error:
`ERROR rpr.init [4913487296]:  set_image_gamma() missing 1 required positional argument: 'rpr_context'`
Error comes from #181.

### EFFECT OF CHANGE
Fixed possible error with UDIM texture.

### TECHNICAL STEPS
Fixed by adding necessary rpr_context argument to set_image_gamma()
