### PR TITLE
Fixed error with viewport material preview

### DIFF
--- a/src/rprblender/export/world.py
+++ b/src/rprblender/export/world.py
@@ -282,6 +282,7 @@ class WorldData:
         data.rotation = (0.0, 0.0, shading.studio_light_rotate_z)
 
         bg_data = WorldData.OverrideData()
+        bg_data.rotation = data.rotation
         if math.isclose(shading.studio_light_background_alpha, 0.0):
             bg_data.intensity = 1.0
             bg_data.color = STUDIO_LIGHT_DEFAULT_COLOR


### PR DESCRIPTION
### PURPOSE
After #178 viewport material preview produces 
```
  File "D:\amd-gpuopen\RadeonProRenderBlenderAddon\src\rprblender\export\world.py", line 72, in set_light_rotation
    euler = mathutils.Euler((rotation[0], rotation[1], rotation[2] - np.pi / 2))
TypeError: 'NoneType' object is not subscriptable
```

### EFFECT OF CHANGE
Fixed error in running viewport material preview.

### TECHNICAL STEPS
Defining rotation to OverideData in init_from_shading_data().
