### PR TITLE
RPRBLND-1583: Viewport optimizations for Northstar

### DIFF
--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -149,11 +149,19 @@ class RPRContext:
 
         return self.frame_buffers_aovs[pyrpr.AOV_COLOR]['res']
 
-    def resolve(self):
-        for aov, fbs in self.frame_buffers_aovs.items():
-            fbs['aov'].resolve(fbs['res'], aov != pyrpr.AOV_SHADOW_CATCHER)
+    def resolve(self, aovs=None):
+        if aovs:
+            for aov in aovs:
+                fbs = self.frame_buffers_aovs[aov]
+                fbs['aov'].resolve(fbs['res'], aov != pyrpr.AOV_SHADOW_CATCHER)
+        else:
+            for aov, fbs in self.frame_buffers_aovs.items():
+                fbs['aov'].resolve(fbs['res'], aov != pyrpr.AOV_SHADOW_CATCHER)
 
         if self.composite:
+            if aovs and pyrpr.AOV_COLOR not in aovs:
+                return
+
             color_aov = self.frame_buffers_aovs[pyrpr.AOV_COLOR]
             self.composite.compute(color_aov['composite'])
             if self.gl_interop:

--- a/src/rprblender/engine/context_hybrid.py
+++ b/src/rprblender/engine/context_hybrid.py
@@ -55,7 +55,7 @@ class RPRContext(context.RPRContext):
             context_props = context_props[2:]
         super().init(context_flags, context_props)
 
-    def resolve(self):
+    def resolve(self, aovs=None):
         pass
 
     def enable_aov(self, aov_type):

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -748,18 +748,8 @@ class ViewportEngine(Engine):
                 self.viewport_settings = viewport_settings
                 self.viewport_settings.export_camera(self.rpr_context.scene.camera)
                 if self.user_settings.adapt_viewport_resolution:
-                    # trying to use previous resolution or almost same pixels number
-                    max_w, max_h = self.viewport_settings.width, self.viewport_settings.height
-                    min_w = max(max_w * self.user_settings.min_viewport_resolution_scale // 100, 1)
-                    min_h = max(max_h * self.user_settings.min_viewport_resolution_scale // 100, 1)
-                    w, h = self.rpr_context.width, self.rpr_context.height
-
-                    if abs(w / h - max_w / max_h) > MIN_ADAPT_RESOLUTION_RATIO_DIFF:
-                        scale = math.sqrt(w * h / (max_w * max_h))
-                        w, h = int(max_w * scale), int(max_h * scale)
-
-                    self._resize(min(max(w, min_w), max_w),
-                                 min(max(h, min_h), max_h))
+                    self._adapt_resize(self.viewport_settings.width, self.viewport_settings.height,
+                                       self.user_settings.min_viewport_resolution_scale * 0.01)
                 else:
                     self._resize(self.viewport_settings.width, self.viewport_settings.height)
 
@@ -768,19 +758,9 @@ class ViewportEngine(Engine):
 
             else:
                 if self.requested_adapt_ratio is not None:
-                    max_w, max_h = self.viewport_settings.width, self.viewport_settings.height
-                    min_w = max(max_w * self.user_settings.min_viewport_resolution_scale // 100, 1)
-                    min_h = max(max_h * self.user_settings.min_viewport_resolution_scale // 100, 1)
-                    if abs(1.0 - self.requested_adapt_ratio) > MIN_ADAPT_RATIO_DIFF:
-                        scale = math.sqrt(self.requested_adapt_ratio)
-                        w, h = int(self.rpr_context.width * scale),\
-                               int(self.rpr_context.height * scale)
-                    else:
-                        w, h = self.rpr_context.width, self.rpr_context.height
-
-                    self._resize(min(max(w, min_w), max_w),
-                                 min(max(h, min_h), max_h))
-
+                    self._adapt_resize(self.viewport_settings.width, self.viewport_settings.height,
+                                       self.user_settings.min_viewport_resolution_scale * 0.01,
+                                       self.requested_adapt_ratio)
                     self.requested_adapt_ratio = None
                     self.is_resolution_adapted = True
 
@@ -812,6 +792,27 @@ class ViewportEngine(Engine):
             self.world_settings.backplate.export(self.rpr_context, (self.width, self.height))
 
         self.is_resized = True
+
+    def _adapt_resize(self, max_w, max_h, min_scale, adapt_ratio=None):
+        # trying to use previous resolution or almost same pixels number
+        min_w = max(int(max_w * min_scale), 1)
+        min_h = max(int(max_h * min_scale), 1)
+        w, h = self.rpr_context.width, self.rpr_context.height
+
+        if adapt_ratio is None:
+            if abs(w / h - max_w / max_h) > MIN_ADAPT_RESOLUTION_RATIO_DIFF:
+                scale = math.sqrt(w * h / (max_w * max_h))
+                w, h = int(max_w * scale), int(max_h * scale)
+        else:
+            if abs(1.0 - adapt_ratio) > MIN_ADAPT_RATIO_DIFF:
+                scale = math.sqrt(adapt_ratio)
+                w, h = int(self.rpr_context.width * scale), \
+                       int(self.rpr_context.height * scale)
+            else:
+                w, h = self.rpr_context.width, self.rpr_context.height
+
+        self._resize(min(max(w, min_w), max_w),
+                     min(max(h, min_h), max_h))
 
     def sync_objects_collection(self, depsgraph):
         """

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -371,9 +371,7 @@ class ViewportEngine(Engine):
                 time_render_prev = time_render
                 time_render = time.perf_counter() - time_begin
                 iteration_time = time_render - time_render_prev
-                if self.user_settings.adapt_viewport_resolution \
-                        and not self.is_resolution_adapted \
-                        and iteration == 2:
+                if not self.is_resolution_adapted and iteration == 2:
                     target_time = 1.0 / self.user_settings.viewport_samples_per_sec
                     self.requested_adapt_ratio = target_time / iteration_time
 
@@ -571,7 +569,7 @@ class ViewportEngine(Engine):
                     sync_collection = True
 
                     if is_updated:
-                        self.is_resolution_adapted = False
+                        self.is_resolution_adapted = not self.user_settings.adapt_viewport_resolution
 
                     continue
 
@@ -731,7 +729,7 @@ class ViewportEngine(Engine):
 
                 self.viewport_settings.export_camera(self.rpr_context.scene.camera)
                 self._resize(self.viewport_settings.width, self.viewport_settings.height)
-                self.is_resolution_adapted = False
+                self.is_resolution_adapted = not self.user_settings.adapt_viewport_resolution
                 self.restart_render_event.set()
 
         if not self.is_rendered:
@@ -765,7 +763,7 @@ class ViewportEngine(Engine):
                 else:
                     self._resize(self.viewport_settings.width, self.viewport_settings.height)
 
-                self.is_resolution_adapted = False
+                self.is_resolution_adapted = not self.user_settings.adapt_viewport_resolution
                 self.restart_render_event.set()
 
             else:

--- a/src/rprblender/engine/viewport_engine_2.py
+++ b/src/rprblender/engine/viewport_engine_2.py
@@ -115,14 +115,17 @@ class ViewportEngine2(ViewportEngine):
                     # clears restart_render_event, prepares to start rendering
                     self.restart_render_event.clear()
 
-                    self.is_resolution_adapted = not self.user_settings.adapt_viewport_resolution
-
                     vs = self.viewport_settings
                     if vs is None:
                         continue
 
-                    if vs.width != self.rpr_context.width or vs.height != self.rpr_context.height:
+                    if self.user_settings.adapt_viewport_resolution:
+                        self._adapt_resize(vs.width, vs.height,
+                                           self.user_settings.min_viewport_resolution_scale * 0.01)
+                    else:
                         self._resize(vs.width, vs.height)
+
+                    self.is_resolution_adapted = not self.user_settings.adapt_viewport_resolution
 
                     vs.export_camera(self.rpr_context.scene.camera)
                     iteration = 0
@@ -174,7 +177,7 @@ class ViewportEngine2(ViewportEngine):
 
                 if iteration == 1 and not self.is_resolution_adapted:
                     w, h = self.rpr_context.width, self.rpr_context.height
-                    self._resize(w // 2, h // 2)
+                    # self._resize(w // 2, h // 2)
 
                     iteration = 0
                     self.is_resolution_adapted = True
@@ -253,6 +256,7 @@ class ViewportEngine2(ViewportEngine):
         # initializing self.viewport_settings and requesting first self.restart_render_event
         if not self.viewport_settings:
             self.viewport_settings = ViewportSettings(context)
+            self._resize(self.viewport_settings.width, self.viewport_settings.height)
             self.restart_render_event.set()
             return
 

--- a/src/rprblender/engine/viewport_engine_2.py
+++ b/src/rprblender/engine/viewport_engine_2.py
@@ -48,6 +48,10 @@ class ViewportEngine2(ViewportEngine):
         self.rpr_context = None
         self.image_filter = None
 
+    def _resolve(self):
+        self.rpr_context.resolve(None if self.image_filter and self.is_last_iteration else
+                                 (pyrpr.AOV_COLOR,))
+        
     def _resize(self, width, height):
         if self.width == width and self.height == height:
             self.is_resized = False

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -158,7 +158,7 @@ class RPR_RENDER_PT_viewport_limits(RPR_Panel):
         if context.scene.rpr.render_quality == 'FULL2':
             row.enabled = False
 
-        adapt_resolution = context.scene.rpr.render_quality != 'FULL2'
+        adapt_resolution = context.scene.rpr.render_quality in ('FULL', 'FULL2')
         col1 = col.column()
         col1.enabled = adapt_resolution
         col1.prop(settings, 'adapt_viewport_resolution')


### PR DESCRIPTION
### PURPOSE
We should try and improve the viewport rendering speed in Northstar:
1.  Enable viewport scaling
2.  Only resolve color AOV for intermediate iterations. Other AOVs should be resolved only at last iteration for image filter needs.

### EFFECT OF CHANGE
Applied adaptive viewport resolution for Full render quality. Applied internal optimizations for viewport rendering.
Enabled Adapt Viewport Resoltion option in Viewport & Preview Sampling panel.

### TECHNICAL STEPS
1. Moved adaptive resolution code in ViewportEngine to _adapt_resize() function, made it available to use in ViewportEngine2.
2. Overrided _resize() in ViewportEngine2.
3. Implemented algorithm of adaptive resolution in ViewportEngine2._do_render().
4. Enabled UI Adapt Viewport Resoltion option.
5. Improved RPRContext.resolve() with aovs parameter. Optimized resolving at intermediate iterations.

### NOTES FOR REVIEWERS
I found that render time at second iteration with CONTEXT_PREVIEW=3 is approximately equal to render time per iteration with CONTEXT_PREVIEW=0 and CONTEXT_ITERATIONS=32. This is quite rough approximation and depends by the scene, but I used this render time as estimation for calculating requested_adapt_ratio value.