### PR TITLE
RPRBLND-1529: Athena issue with Hybrid.

### DIFF
--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -550,8 +550,13 @@ class RenderEngine(Engine):
             for o in self.rpr_context.objects.values() if isinstance(o, pyrpr.Shape)
         )
         data['Num Textures'] = len(self.rpr_context.images)
-        data['Textures Size'] = sum(im.size_byte for im in self.rpr_context.images.values()) \
-                                // (1024 * 1024)  # in MB
+
+        # temporary ignore getting texture sizes with hybrid,
+        # until it'll be fixed on hybrid core side
+        from . context_hybrid import RPRContext as RPRContextHybrid
+        if not isinstance(self.rpr_context, RPRContextHybrid):
+            data['Textures Size'] = sum(im.size_byte for im in self.rpr_context.images.values()) \
+                                    // (1024 * 1024)  # in MB
 
         data['RIF Type'] = self.image_filter.settings['filter_type'] if self.image_filter else None
 


### PR DESCRIPTION
### PURPOSE
This fix relates to #153 #196.
This is hybrid core issue, and probably it'll be fixed in next core. But currently we can do short fix on plugin side.

### EFFECT OF CHANGE
Fixed exception related to getting stats data in low/medium/hight render quality in final render.

### TECHNICAL STEPS
Temporary ignore getting texture sizes with hybrid, until it'll be fixed on hybrid core side.
