### PR TITLE
RPRBLND-1664: Add support for ML denoiser + upscale

### DIFF
--- a/src/rprblender/engine/engine.py
+++ b/src/rprblender/engine/engine.py
@@ -55,6 +55,7 @@ class Engine:
         # image filters
         self.image_filter = None
         self.background_filter = None
+        self.upscale_filter = None
 
     def _set_render_result(self, render_passes: bpy.types.RenderPasses, apply_image_filter):
         """
@@ -447,3 +448,37 @@ class Engine:
 
         self.background_filter.update_input('color', color_image, tile_pos)
         self.background_filter.update_input('opacity', opacity_image, tile_pos)
+
+    def setup_upscale_filter(self, settings):
+        if self.upscale_filter and self.upscale_filter.settings == settings:
+            return False
+
+        if settings['enable']:
+            if not self.upscale_filter:
+                self._enable_upscale_filter(settings)
+
+            elif self.upscale_filter.settings['resolution'] == settings['resolution']:
+                return False
+
+            else:
+                # recreating filter
+                self._disable_upscale_filter()
+                self._enable_upscale_filter(settings)
+
+        elif self.upscale_filter:
+            self._disable_upscale_filter()
+
+        return True
+
+    def _enable_upscale_filter(self, settings):
+        width, height = settings['resolution']
+
+        self.rpr_context.enable_aov(pyrpr.AOV_COLOR)
+
+        self.upscale_filter = image_filter.ImageFilterUpscale(
+            self.rpr_context.context, {'color'}, {}, {}, width, height)
+
+        self.upscale_filter.settings = settings
+
+    def _disable_upscale_filter(self):
+        self.upscale_filter = None

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -298,3 +298,21 @@ class ImageFilterTransparentBackground(ImageFilter):
         self.filter = self.setup_alpha_filter(self.inputs['opacity'])
 
         self.command_queue.attach_image_filter(self.filter, self.inputs['color'], self.output_image)
+
+
+class ImageFilterUpscale(ImageFilter):
+    """ Apply transparent background only """
+
+    def _create_filter(self):
+        self.filter = self.context.create_filter(rif.IMAGE_FILTER_AI_UPSCALE)
+
+        models_path = utils.package_root_dir() / 'data/models'
+        if not models_path.is_dir():
+            # set alternative path
+            models_path = utils.package_root_dir() / '../../.sdk/rif/models'
+        self.filter.set_parameter('modelPath', str(models_path))
+
+        self.filter.set_parameter('mode', rif.AI_UPSCALE_MODE_GOOD_2X)
+
+        self.output_image = self.context.create_image(self.width * 2, self.height * 2)
+        self.command_queue.attach_image_filter(self.filter, self.inputs['color'], self.output_image)

--- a/src/rprblender/engine/image_filter.py
+++ b/src/rprblender/engine/image_filter.py
@@ -312,7 +312,7 @@ class ImageFilterUpscale(ImageFilter):
             models_path = utils.package_root_dir() / '../../.sdk/rif/models'
         self.filter.set_parameter('modelPath', str(models_path))
 
-        self.filter.set_parameter('mode', rif.AI_UPSCALE_MODE_GOOD_2X)
+        self.filter.set_parameter('mode', rif.AI_UPSCALE_MODE_BEST_2X)
 
         self.output_image = self.context.create_image(self.width * 2, self.height * 2)
         self.command_queue.attach_image_filter(self.filter, self.inputs['color'], self.output_image)

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -1041,6 +1041,11 @@ class ViewportEngine(Engine):
             self.denoised_image = None
             restart = True
 
+        restart |= self.setup_upscale_filter({
+            'enable': get_user_settings().viewport_resolution_upscale,
+            'resolution': (self.width, self.height),
+        })
+
         return restart
 
     def _get_world_settings(self, depsgraph):

--- a/src/rprblender/engine/viewport_engine_2.py
+++ b/src/rprblender/engine/viewport_engine_2.py
@@ -130,10 +130,10 @@ class ViewportEngine2(ViewportEngine):
                         continue
 
                     if self.user_settings.adapt_viewport_resolution:
-                        self._adapt_resize(vs.width, vs.height,
+                        self._adapt_resize(*self._get_resolution(vs),
                                            self.user_settings.min_viewport_resolution_scale * 0.01)
                     else:
-                        self._resize(vs.width, vs.height)
+                        self._resize(*self._get_resolution(vs))
 
                     self.is_resolution_adapted = not self.user_settings.adapt_viewport_resolution
 
@@ -273,7 +273,7 @@ class ViewportEngine2(ViewportEngine):
         # initializing self.viewport_settings and requesting first self.restart_render_event
         if not self.viewport_settings:
             self.viewport_settings = ViewportSettings(context)
-            self._resize(self.viewport_settings.width, self.viewport_settings.height)
+            self._resize(*self._get_resolution())
             self.restart_render_event.set()
             return
 

--- a/src/rprblender/engine/viewport_engine_2.py
+++ b/src/rprblender/engine/viewport_engine_2.py
@@ -188,7 +188,7 @@ class ViewportEngine2(ViewportEngine):
                     target_time = 1.0 / self.user_settings.viewport_samples_per_sec
                     self.requested_adapt_ratio = target_time / iteration_time
 
-                    self._adapt_resize(self.viewport_settings.width, self.viewport_settings.height,
+                    self._adapt_resize(*self._get_resolution(self.viewport_settings),
                                        self.user_settings.min_viewport_resolution_scale * 0.01,
                                        self.requested_adapt_ratio)
 

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -242,7 +242,7 @@ class RPR_UserSettings(bpy.types.PropertyGroup):
         description="Denoise rendered image with Machine Learning denoiser.\n"
                     "Rendering at 2 times lower resoluting then upscaling rendered image "
                     "in the end of render",
-        default=False,
+        default=True,
     )
 
 

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -239,7 +239,8 @@ class RPR_UserSettings(bpy.types.PropertyGroup):
 
     viewport_resolution_upscale: BoolProperty(
         name="Upscale Resolution",
-        description="Rendering at 2 times lower resoluting then upscaling it in the end of render",
+        description="Rendering at 2 times lower resoluting then upscaling rendered image "
+                    "in the end of render",
         default=False,
     )
 

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -237,9 +237,10 @@ class RPR_UserSettings(bpy.types.PropertyGroup):
         min=5, max=100, default=25,
     )
 
-    viewport_resolution_upscale: BoolProperty(
-        name="Upscale Resolution",
-        description="Rendering at 2 times lower resoluting then upscaling rendered image "
+    viewport_denoiser_upscale: BoolProperty(
+        name="Viewport Denoising and Upscaling",
+        description="Denoise rendered image with Machine Learning denoiser.\n"
+                    "Rendering at 2 times lower resoluting then upscaling rendered image "
                     "in the end of render",
         default=False,
     )

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -237,6 +237,12 @@ class RPR_UserSettings(bpy.types.PropertyGroup):
         min=5, max=100, default=25,
     )
 
+    viewport_resolution_upscale: BoolProperty(
+        name="Upscale Resolution",
+        description="Rendering at 2 times lower resoluting then upscaling it in the end of render",
+        default=False,
+    )
+
 
 class RPR_RenderProperties(RPR_Properties):
     """ Main render properties. Available from scene.rpr """

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -170,6 +170,8 @@ class RPR_RENDER_PT_viewport_limits(RPR_Panel):
 
         col.prop(settings, 'use_gl_interop')
 
+        col.prop(settings, 'viewport_resolution_upscale')
+
         col.separator()
         col.prop(limits, 'preview_samples')
         col.prop(limits, 'preview_update_samples')

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -170,7 +170,7 @@ class RPR_RENDER_PT_viewport_limits(RPR_Panel):
 
         col.prop(settings, 'use_gl_interop')
 
-        col.prop(settings, 'viewport_resolution_upscale')
+        col.prop(settings, 'viewport_denoiser_upscale')
 
         col.separator()
         col.prop(limits, 'preview_samples')


### PR DESCRIPTION
### PURPOSE
RIF has upscale ML filter, which provides us to render at lower resolution in viewport and upscaling rendered image.

### EFFECT OF CHANGE
Enabled upscaling in viewport render, which provides faster render at 2-times lower resolution and upscaling rendered image. Added correspondent option in viewport sampling tab.

### TECHNICAL STEPS
1. Added class ImageFilterUpscale.
2. Added Engine.upscale_filter and correspondent methods.
3. Added viewport_resolution_upscale property in user settings, added this property in UI in viewport sampling tab.
4. Implemented upscale_filter usage in ViewportEngine and ViewportEngine2.
