### PR TITLE
RPRBLND-1635: Tree creature scene doesn't free memory.

### DIFF
--- a/src/rprblender/__init__.py
+++ b/src/rprblender/__init__.py
@@ -97,10 +97,11 @@ class RPREngine(bpy.types.RenderEngine):
     engine: Engine = None
 
     def __del__(self):
-        log('__del__', self.as_pointer())
-
         if isinstance(self.engine, ViewportEngine):
             self.engine.stop_render()
+
+        log('__del__', self.as_pointer())
+
 
     # final render
     def update(self, data, depsgraph):
@@ -126,7 +127,7 @@ class RPREngine(bpy.types.RenderEngine):
             self.error_set(f"ERROR | {e}. Please see log for more details.")
 
     def render(self, depsgraph):
-        """ Called with both final render and viewport """
+        """ Called with final render and preview """
         log("render", self.as_pointer())
         try:
             self.engine.render()
@@ -135,9 +136,13 @@ class RPREngine(bpy.types.RenderEngine):
             log.error(e, 'EXCEPTION:', traceback.format_exc())
             self.error_set(f"ERROR | {e}. Please see log for more details.")
 
+        # This has to be called in the end of render due to possible memory leak RPRBLND-1635
+        # Important to call it in this function, not in __del__()
+        self.engine.stop_render()
+
     # viewport render
     def view_update(self, context, depsgraph):
-        """ called when data is updated for viewport """
+        """ Called when data is updated for viewport """
         log('view_update', self.as_pointer())
 
         try:

--- a/src/rprblender/engine/engine.py
+++ b/src/rprblender/engine/engine.py
@@ -56,6 +56,11 @@ class Engine:
         self.image_filter = None
         self.background_filter = None
 
+    def stop_render(self):
+        self.rpr_context = None
+        self.image_filter = None
+        self.background_filter = None
+
     def _set_render_result(self, render_passes: bpy.types.RenderPasses, apply_image_filter):
         """
         Sets render result to render passes


### PR DESCRIPTION
### PURPOSE
When scene has material with big node tree structure (for example lot of nodes with internal arithmetic) it can be not freed from memory in the end of rendering.

### EFFECT OF CHANGE
Fixed possible memory leak in final render with scenes with big material node tree.

### TECHNICAL STEPS
Fixed by explicit calling stop_render() in the end of render() function.
