### PR TITLE
Disable upscaler on MACOS

### DIFF
--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -242,7 +242,7 @@ class RPR_UserSettings(bpy.types.PropertyGroup):
         description="Denoise rendered image with Machine Learning denoiser.\n"
                     "Rendering at 2 times lower resoluting then upscaling rendered image "
                     "in the end of render",
-        default=True,
+        default=True if not utils.IS_MAC else False, # TODO remove when macos upscaler fixed
     )
 
 


### PR DESCRIPTION
### PURPOSE
RIF macOS has an issue with upscaling filter.

### EFFECT OF CHANGE
Disable viewport upscaling on macos

### NOTES FOR REVIEWERS
@bnagirniak I think we should still be doing viewport denoising but that is a deeper change.