### PR TITLE
Add support for setting texture compression.  Default to false

### DIFF
--- a/src/bindings/pyrpr/src/pyrpr.py
+++ b/src/bindings/pyrpr/src/pyrpr.py
@@ -1391,6 +1391,9 @@ class Image(Object):
     def set_colorspace(self, colorspace):
         ImageSetOcioColorspace(self, encode(colorspace))
 
+    def set_compression(self, compression):
+        ImageSetInternalCompression(self, compression)
+
     @property
     def size_byte(self):
         if self._size_byte is None:

--- a/src/rprblender/engine/context.py
+++ b/src/rprblender/engine/context.py
@@ -80,6 +80,9 @@ class RPRContext:
         self.use_reflection_catcher = False
         self.use_transparent_background = False
 
+        # texture compression used when images created
+        self.texture_compression = False
+
     def init(self, context_flags, context_props, use_contour_integrator=False):
         self.context = self._Context(context_flags, context_props)
         self.material_system = pyrpr.MaterialSystem(self.context)
@@ -452,12 +455,14 @@ class RPRContext:
 
     def create_image_file(self, key, filepath):
         image = pyrpr.ImageFile(self.context, filepath)
+        image.set_compression = self.compress_textures
         if key:
             self.images[key] = image
         return image
 
     def create_image_data(self, key, data):
         image = pyrpr.ImageData(self.context, data)
+        image.set_compression = self.compress_textures
         if key:
             self.images[key] = image
         return image

--- a/src/rprblender/engine/export_engine.py
+++ b/src/rprblender/engine/export_engine.py
@@ -74,6 +74,7 @@ class ExportEngine(Engine):
         # rpr_context parameters
         self.rpr_context.set_parameter(pyrpr.CONTEXT_PREVIEW, False)
         scene.rpr.export_ray_depth(self.rpr_context)
+        self.rpr_context.texture_compression = scene.rpr.texture_compression
 
         # EXPORT CAMERA
         camera_key = object.key(scene.camera)   # current camera key

--- a/src/rprblender/engine/preview_engine.py
+++ b/src/rprblender/engine/preview_engine.py
@@ -113,6 +113,7 @@ class PreviewEngine(Engine):
         self.rpr_context.set_parameter(pyrpr.CONTEXT_PREVIEW, True)
         settings_scene.rpr.export_ray_depth(self.rpr_context)
         settings_scene.rpr.export_pixel_filter(self.rpr_context)
+        self.rpr_context.texture_compression = settings_scene.rpr.texture_compression
 
         self.render_samples = settings_scene.rpr.viewport_limits.preview_samples
         self.render_update_samples = settings_scene.rpr.viewport_limits.preview_update_samples

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -508,6 +508,7 @@ class RenderEngine(Engine):
         self.rpr_context.set_parameter(pyrpr.CONTEXT_PREVIEW, False)
         scene.rpr.export_ray_depth(self.rpr_context)
         scene.rpr.export_pixel_filter(self.rpr_context)
+        self.rpr_context.texture_compression = scene.rpr.texture_compression
 
         self.render_samples, self.render_time = (scene.rpr.limits.max_samples, scene.rpr.limits.seconds)
 

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -516,6 +516,7 @@ class ViewportEngine(Engine):
         self.rpr_context.set_parameter(pyrpr.CONTEXT_ITERATIONS, 1)
         scene.rpr.export_render_mode(self.rpr_context)
         scene.rpr.export_ray_depth(self.rpr_context)
+        self.rpr_context.texture_compression = scene.rpr.texture_compression
         scene.rpr.export_pixel_filter(self.rpr_context)
 
         self.render_iterations, self.render_time = (viewport_limits.max_samples, 0)

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -466,6 +466,12 @@ class RPR_RenderProperties(RPR_Properties):
         default=False,
     )
 
+    texture_compression: BoolProperty(
+        name="Texture Compression",
+        description="Enables Texture compression for faster rendering (with lossier textures)",
+        default=False,
+    )
+
     motion_blur_in_velocity_aov: BoolProperty(
         name="Only in Velocity AOV",
         description="Apply Motion Blur in Velocity AOV only\nOnly for Full render quality",

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -196,6 +196,9 @@ class RPR_RENDER_PT_quality(RPR_Panel):
         if rpr.render_quality in ('LOW', 'MEDIUM', 'HIGH'):
             self.layout.prop(rpr, 'hybrid_low_mem')
 
+        if rpr.render_quality == 'FULL2':
+            self.layout.prop(rpr, texture_compression)
+
 
 class RPR_RENDER_PT_max_ray_depth(RPR_Panel):
     bl_label = "Max Ray Depth"


### PR DESCRIPTION
### PURPOSE
Many issues persist with texture compression with RPR.  Setting to false fixes many

### EFFECT OF CHANGE
Less issues with texture compression

### TECHNICAL STEPS
we set this globally rather than per texture.  Thus is set on rpr_context.