### PR TITLE
RPRBLND-1631 Fixed Viewport Material Preview mode sync crash

### DIFF
--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -457,7 +457,8 @@ class ViewportEngine(Engine):
         """
 
         try:
-            time.sleep(0.1)  # give Blender time to fully transfer depsgraph data to thread to prevent access violation
+            # (fixes RPRBLND-1631) give Blender time to fully transfer depsgraph data to thread to prevent access violation
+            time.sleep(0.1)
             self._do_sync(depsgraph)
             self._do_render()
 

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -457,6 +457,7 @@ class ViewportEngine(Engine):
         """
 
         try:
+            time.sleep(0.1)  # give Blender time to fully transfer depsgraph data to thread to prevent access violation
             self._do_sync(depsgraph)
             self._do_render()
 


### PR DESCRIPTION
### PURPOSE
Some big scene causes crash on Viewport Material Preview mode activation due to the access vialation. It appeared that crash happens randomly on depsgraph.objects access on some objects from the Viewport syncronisation thread if objects number is high enough.
There is no way from the Python side to tell beforehand which object will fail since crash is caused by object info access attempt.
After investigation it appeared that a small delay(be it an excessive logging or time.sleep) in thread sync loop activation allows Blender to process depsgraph data passed to the thread cortrectly thus removing crash.
Overall sync time is not affected since combined sync time is times and times bigger than delay.

### EFFECT OF CHANGE
- fixed issue with Viewport crash on some scenes with big number of objects.

### TECHNICAL STEPS
- added short (0.1 second) delay to Viewport thread sync process start.