### PR TITLE
Fixed RIF libraries for Ubuntu

### DIFF
--- a/cmd_tools/create_sdk.py
+++ b/cmd_tools/create_sdk.py
@@ -89,7 +89,7 @@ def copy_rif_sdk():
     # getting rif bin_dir
     os_str = {
         'Windows': "Windows",
-        'Linux': "Ubuntu18",
+        'Linux': "Ubuntu18-Clang",
         'Darwin': "OSX"
     }[OS]
     bin_dir = rif_dir / os_str / "Dynamic"

--- a/cmd_tools/create_sdk.py
+++ b/cmd_tools/create_sdk.py
@@ -89,7 +89,7 @@ def copy_rif_sdk():
     # getting rif bin_dir
     os_str = {
         'Windows': "Windows",
-        'Linux': "Ubuntu18-Clang",
+        'Linux': "Ubuntu20",
         'Darwin': "OSX"
     }[OS]
     bin_dir = rif_dir / os_str / "Dynamic"


### PR DESCRIPTION
### PURPOSE
Due to the changes in RIF libraries(dropped support for Ubuntu18) the Ubuntu18 binaries weren't updated. The Ubuntu20 binaries should be used instead.

### EFFECT OF CHANGE
- Fixed image filters on Ubuntu20.

### TECHNICAL STEPS
- changed path to the RIF libraries in plugin builder