### PR TITLE
RPRBLND-1896: Case scene.world == None isn't handled by plugin.

### DIFF
--- a/README-OSX.md
+++ b/README-OSX.md
@@ -5,7 +5,7 @@ has some specific requirements.
 
 ### Prerequisites:
 
-- The High Sierra OS 10.13.3 or later is required
+- The Mojave OS 10.14 or later is required.  To use RPR2, 10.15 is required.
     - We only use the Metal code path for this addon and this is the reason for this requirement
 - Install Xcode
     - SDKROOT should be set in your .profile:

--- a/src/rprblender/engine/preview_engine.py
+++ b/src/rprblender/engine/preview_engine.py
@@ -110,9 +110,9 @@ class PreviewEngine(Engine):
         camera.sync(self.rpr_context, depsgraph.objects[depsgraph.scene.camera.name])
 
         # export world only if active_material.use_preview_world is enabled
-        preview_obj = next(obj for obj in self.depsgraph_objects(depsgraph)
-                               if obj.name.startswith('preview_'))
-        if preview_obj.active_material and preview_obj.active_material.use_preview_world:
+        preview_obj = next((obj for obj in self.depsgraph_objects(depsgraph)
+                               if obj.name.startswith('preview_')), None)
+        if preview_obj is not None and preview_obj.active_material and preview_obj.active_material.use_preview_world:
             world.sync(self.rpr_context, settings_scene.world)
 
         self.rpr_context.enable_aov(pyrpr.AOV_COLOR)

--- a/src/rprblender/engine/preview_engine.py
+++ b/src/rprblender/engine/preview_engine.py
@@ -112,8 +112,8 @@ class PreviewEngine(Engine):
         # export world only if active_material.use_preview_world is enabled
         preview_obj = next((obj for obj in self.depsgraph_objects(depsgraph)
                                if obj.name.startswith('preview_')), None)
-        if preview_obj is not None and settings_scene.world is not None and \
-                preview_obj.active_material and preview_obj.active_material.use_preview_world:
+        if preview_obj and settings_scene.world and preview_obj.active_material \
+                and preview_obj.active_material.use_preview_world:
             world.sync(self.rpr_context, settings_scene.world)
 
         self.rpr_context.enable_aov(pyrpr.AOV_COLOR)

--- a/src/rprblender/engine/preview_engine.py
+++ b/src/rprblender/engine/preview_engine.py
@@ -112,7 +112,8 @@ class PreviewEngine(Engine):
         # export world only if active_material.use_preview_world is enabled
         preview_obj = next((obj for obj in self.depsgraph_objects(depsgraph)
                                if obj.name.startswith('preview_')), None)
-        if preview_obj is not None and preview_obj.active_material and preview_obj.active_material.use_preview_world:
+        if preview_obj is not None and settings_scene.world is not None and \
+                preview_obj.active_material and preview_obj.active_material.use_preview_world:
             world.sync(self.rpr_context, settings_scene.world)
 
         self.rpr_context.enable_aov(pyrpr.AOV_COLOR)

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -672,7 +672,7 @@ class RenderEngine(Engine):
             self.camera_data.export(rpr_camera)
 
         # Environment is synced once per frame
-        if scene.world is not None:
+        if scene.world:
             if scene.world.is_evaluated:  # for some reason World data can came in unevaluated
                 world_data = scene.world
             else:

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -672,12 +672,13 @@ class RenderEngine(Engine):
             self.camera_data.export(rpr_camera)
 
         # Environment is synced once per frame
-        if scene.world.is_evaluated:  # for some reason World data can came in unevaluated
-            world_data = scene.world
-        else:
-            world_data = scene.world.evaluated_get(depsgraph)
-        world_settings = world.sync(self.rpr_context, world_data)
-        self.world_backplate = world_settings.backplate
+        if scene.world is not None:
+            if scene.world.is_evaluated:  # for some reason World data can came in unevaluated
+                world_data = scene.world
+            else:
+                world_data = scene.world.evaluated_get(depsgraph)
+            world_settings = world.sync(self.rpr_context, world_data)
+            self.world_backplate = world_settings.backplate
 
         # EXPORT PARTICLES
         # Note: particles should be exported after motion blur,

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -500,8 +500,9 @@ class ViewportEngine(Engine):
 
         self.rpr_context.scene.set_name(scene.name)
 
-        self.world_settings = self._get_world_settings(depsgraph)
-        self.world_settings.export(self.rpr_context)
+        if scene.world is not None:
+            self.world_settings = self._get_world_settings(depsgraph)
+            self.world_settings.export(self.rpr_context)
 
         rpr_camera = self.rpr_context.create_camera()
         rpr_camera.set_name("Camera")

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -500,7 +500,7 @@ class ViewportEngine(Engine):
 
         self.rpr_context.scene.set_name(scene.name)
 
-        if scene.world is not None:
+        if scene.world:
             self.world_settings = self._get_world_settings(depsgraph)
             self.world_settings.export(self.rpr_context)
 

--- a/src/rprblender/ui/world.py
+++ b/src/rprblender/ui/world.py
@@ -24,12 +24,18 @@ class RPR_WORLD_PT_environment(RPR_Panel):
     bl_context = 'world'
 
     def draw_header(self, context):
+        if context.scene.world is None:
+            return
+
         self.layout.prop(context.scene.world.rpr, 'enabled', text="")
 
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
+
+        if context.scene.world is None:
+            return
 
         rpr = context.scene.world.rpr
 
@@ -71,6 +77,9 @@ class RPR_EnvironmentOverride(RPR_Panel):
     type = ''
 
     def draw_header(self, context):
+        if context.scene.world is None:
+            return
+
         rpr = context.scene.world.rpr
         row = self.layout.row()
         row.enabled = rpr.enabled
@@ -146,6 +155,9 @@ class RPR_WORLD_PT_gizmo(RPR_Panel):
     bl_parent_id = 'RPR_WORLD_PT_environment'
 
     def draw(self, context):
+        if context.scene.world is None:
+            return
+
         rpr = context.scene.world.rpr
 
         layout = self.layout
@@ -163,6 +175,9 @@ class RPR_WORLD_PT_sun_sky(RPR_Panel):
 
     @classmethod
     def poll(cls, context):
+        if context.scene.world is None:
+            return
+
         return super().poll(context) and context.scene.world.rpr.mode == 'SUN_SKY'
 
     def draw(self, context):

--- a/src/rprblender/ui/world.py
+++ b/src/rprblender/ui/world.py
@@ -86,6 +86,9 @@ class RPR_EnvironmentOverride(RPR_Panel):
         row.prop(rpr, f'{self.type}_override', text="")
 
     def draw(self, context):
+        if context.scene.world is None:
+            return
+
         rpr = context.scene.world.rpr
 
         layout = self.layout
@@ -109,7 +112,11 @@ class RPR_WORLD_PT_background_override(RPR_EnvironmentOverride):
     type = 'background'
 
     def draw(self, context):
+        if context.scene.world is None:
+            return
+
         rpr = context.scene.world.rpr
+
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
@@ -176,11 +183,14 @@ class RPR_WORLD_PT_sun_sky(RPR_Panel):
     @classmethod
     def poll(cls, context):
         if context.scene.world is None:
-            return
+            return super().poll(context)
 
         return super().poll(context) and context.scene.world.rpr.mode == 'SUN_SKY'
 
     def draw(self, context):
+        if context.scene.world is None:
+            return
+
         rpr = context.scene.world.rpr
         sun_sky = rpr.sun_sky
 

--- a/src/rprblender/ui/world.py
+++ b/src/rprblender/ui/world.py
@@ -23,19 +23,20 @@ class RPR_WORLD_PT_environment(RPR_Panel):
     bl_space_type = "PROPERTIES"
     bl_context = 'world'
 
-    def draw_header(self, context):
-        if context.scene.world is None:
-            return
+    @classmethod
+    def poll(cls, context):
+        if not context.scene.world:
+            return False
 
+        return super().poll(context)
+
+    def draw_header(self, context):
         self.layout.prop(context.scene.world.rpr, 'enabled', text="")
 
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
-
-        if context.scene.world is None:
-            return
 
         rpr = context.scene.world.rpr
 
@@ -77,18 +78,12 @@ class RPR_EnvironmentOverride(RPR_Panel):
     type = ''
 
     def draw_header(self, context):
-        if context.scene.world is None:
-            return
-
         rpr = context.scene.world.rpr
         row = self.layout.row()
         row.enabled = rpr.enabled
         row.prop(rpr, f'{self.type}_override', text="")
 
     def draw(self, context):
-        if context.scene.world is None:
-            return
-
         rpr = context.scene.world.rpr
 
         layout = self.layout
@@ -112,9 +107,6 @@ class RPR_WORLD_PT_background_override(RPR_EnvironmentOverride):
     type = 'background'
 
     def draw(self, context):
-        if context.scene.world is None:
-            return
-
         rpr = context.scene.world.rpr
 
         layout = self.layout
@@ -162,9 +154,6 @@ class RPR_WORLD_PT_gizmo(RPR_Panel):
     bl_parent_id = 'RPR_WORLD_PT_environment'
 
     def draw(self, context):
-        if context.scene.world is None:
-            return
-
         rpr = context.scene.world.rpr
 
         layout = self.layout
@@ -182,15 +171,9 @@ class RPR_WORLD_PT_sun_sky(RPR_Panel):
 
     @classmethod
     def poll(cls, context):
-        if context.scene.world is None:
-            return super().poll(context)
-
         return super().poll(context) and context.scene.world.rpr.mode == 'SUN_SKY'
 
     def draw(self, context):
-        if context.scene.world is None:
-            return
-
         rpr = context.scene.world.rpr
         sun_sky = rpr.sun_sky
 


### PR DESCRIPTION
### PURPOSE
There is errors in console during rendering and UI operations if we delete world light from scene.

### EFFECT OF CHANGE
No more errors if world light doesn't exist.

### TECHNICAL STEPS
Added checks for world light everywhere it is needed