### PR TITLE
RPRBLND-1896: Case scene.world == None isn't handled by plugin.

### DIFF
--- a/src/rprblender/engine/preview_engine.py
+++ b/src/rprblender/engine/preview_engine.py
@@ -110,10 +110,10 @@ class PreviewEngine(Engine):
         camera.sync(self.rpr_context, depsgraph.objects[depsgraph.scene.camera.name])
 
         # export world only if active_material.use_preview_world is enabled
-        preview_obj = next(obj for obj in self.depsgraph_objects(depsgraph)
-                               if obj.name.startswith('preview_'))
-        if preview_obj.active_material and preview_obj.active_material.use_preview_world:
-            world.sync(self.rpr_context, settings_scene.world)
+        preview_obj = next((obj for obj in self.depsgraph_objects(depsgraph)
+                            if obj.name.startswith('preview_')), None)
+        if preview_obj and settings_scene.world and preview_obj.active_material \
+                and preview_obj.active_material.use_preview_world:
 
         self.rpr_context.enable_aov(pyrpr.AOV_COLOR)
         self.rpr_context.enable_aov(pyrpr.AOV_DEPTH)

--- a/src/rprblender/engine/preview_engine.py
+++ b/src/rprblender/engine/preview_engine.py
@@ -114,6 +114,7 @@ class PreviewEngine(Engine):
                             if obj.name.startswith('preview_')), None)
         if preview_obj and settings_scene.world and preview_obj.active_material \
                 and preview_obj.active_material.use_preview_world:
+            world.sync(self.rpr_context, settings_scene.world)
 
         self.rpr_context.enable_aov(pyrpr.AOV_COLOR)
         self.rpr_context.enable_aov(pyrpr.AOV_DEPTH)

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -680,8 +680,6 @@ class RenderEngine(Engine):
                     world_data = scene.world.evaluated_get(depsgraph)
                 world_settings = world.sync(self.rpr_context, world_data)
                 self.world_backplate = world_settings.backplate
-            world_settings = world.sync(self.rpr_context, world_data)
-            self.world_backplate = world_settings.backplate
 
             # EXPORT PARTICLES
             # Note: particles should be exported after motion blur,

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -673,10 +673,13 @@ class RenderEngine(Engine):
                 self.camera_data.export(rpr_camera)
 
             # Environment is synced once per frame
-            if scene.world.is_evaluated:  # for some reason World data can came in unevaluated
-                world_data = scene.world
-            else:
-                world_data = scene.world.evaluated_get(depsgraph)
+            if scene.world:
+                if scene.world.is_evaluated:  # for some reason World data can came in unevaluated
+                    world_data = scene.world
+                else:
+                    world_data = scene.world.evaluated_get(depsgraph)
+                world_settings = world.sync(self.rpr_context, world_data)
+                self.world_backplate = world_settings.backplate
             world_settings = world.sync(self.rpr_context, world_data)
             self.world_backplate = world_settings.backplate
 

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -501,8 +501,9 @@ class ViewportEngine(Engine):
 
         self.rpr_context.scene.set_name(scene.name)
 
-        self.world_settings = self._get_world_settings(depsgraph)
-        self.world_settings.export(self.rpr_context)
+        if scene.world:
+            self.world_settings = self._get_world_settings(depsgraph)
+            self.world_settings.export(self.rpr_context)
 
         rpr_camera = self.rpr_context.create_camera()
         rpr_camera.set_name("Camera")

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -868,7 +868,7 @@ class ViewportEngine(Engine):
             upscale_filter_settings['resolution'] = self.width, self.height
             self.setup_upscale_filter(upscale_filter_settings)
 
-        if self.world_settings.backplate:
+        if self.world_settings and self.world_settings.backplate:
             self.world_settings.backplate.export(self.rpr_context, (self.width, self.height))
 
         self.is_resized = True

--- a/src/rprblender/ui/world.py
+++ b/src/rprblender/ui/world.py
@@ -23,6 +23,13 @@ class RPR_WORLD_PT_environment(RPR_Panel):
     bl_space_type = "PROPERTIES"
     bl_context = 'world'
 
+    @classmethod
+    def poll(cls, context):
+        if not context.scene.world:
+            return False
+
+        return super().poll(context)
+
     def draw_header(self, context):
         self.layout.prop(context.scene.world.rpr, 'enabled', text="")
 

--- a/src/rprblender/ui/world.py
+++ b/src/rprblender/ui/world.py
@@ -25,10 +25,7 @@ class RPR_WORLD_PT_environment(RPR_Panel):
 
     @classmethod
     def poll(cls, context):
-        if not context.scene.world:
-            return False
-
-        return super().poll(context)
+        return super().poll(context) and context.scene.world
 
     def draw_header(self, context):
         self.layout.prop(context.scene.world.rpr, 'enabled', text="")


### PR DESCRIPTION
PURPOSE
There is errors in console during rendering and UI operations if we delete world light from scene.

EFFECT OF CHANGE
No more errors if world light doesn't exist.

TECHNICAL STEPS
Added checks for world light everywhere it is needed