### PR TITLE
RPRBLND-2072: AttributeError: 'EmptyMaterialNode' object has no attribute '_handle_ptr'.

### DIFF
--- a/src/bindings/pyrpr/src/pyhybrid.py
+++ b/src/bindings/pyrpr/src/pyhybrid.py
@@ -171,6 +171,9 @@ class EmptyMaterialNode(MaterialNode):
     def set_input(self, name, value):
         pass
 
+    def set_id(self, id):
+        pass
+
 
 class Shape(pyrpr.Shape):
     def set_volume_material(self, material):

--- a/src/bindings/pyrpr/src/pyhybridpro.py
+++ b/src/bindings/pyrpr/src/pyhybridpro.py
@@ -186,6 +186,9 @@ class EmptyMaterialNode(MaterialNode):
     def set_input(self, name, value):
         pass
 
+    def set_id(self, id):
+        pass
+
 
 class Shape(pyrpr.Shape):
     def set_volume_material(self, material):


### PR DESCRIPTION
### PURPOSE
Fix exception for unsupported material nodes.

### EFFECT OF CHANGE
Fixed exception for unsupported material nodes.

### TECHNICAL STEPS
Added implementation of set_id method for 'EmptyMaterialNode'.
