### PR TITLE
Fix pingpong math

### DIFF
--- a/src/rprblender/nodes/blender_nodes.py
+++ b/src/rprblender/nodes/blender_nodes.py
@@ -1533,7 +1533,7 @@ class ShaderNodeMath(NodeParser):
                 res = self.create_arithmetic(pyrpr.MATERIAL_NODE_OP_MOD, in1, in2)
             elif op == 'PINGPONG':
                 # Implementation from Blender: source/blender/blenlib/intern/ math_base_inline.c
-                res = (in2 != 0.0).if_else(abs((((in1 - in2) / (in2 * 2.0)) % 1.0) * in2 * 2.0 - in2), 0.0)
+                res = (in2 != 0.0).if_else(abs(((abs((in1 - in2)) / (in2 * 2.0)) % 1.0) * in2 * 2.0 - in2), 0.0)
 
             else:
                 in3 = self.get_input_value(2)


### PR DESCRIPTION
### PURPOSE
Pingpong math is broken when the input is less than zero
### EFFECT OF CHANGE
Pingpong math will match cycles/eevee

### TECHNICAL STEPS
Added an abs to the initial subtraction in the pingpong math

### NOTES FOR REVIEWERS
The center of the render is UV 0

Setup 
![33305ca9-d5c6-430a-811e-3262380884bbc7b854a862](https://user-images.githubusercontent.com/4957057/234735143-77de5267-f1ca-49d6-a548-28fb80cccd54.jpg)



Sample file
[prorenderpingpong.zip](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderBlenderAddon/files/11338633/prorenderpingpong.zip)

Prorender:
![ProrenderPrePatch](https://user-images.githubusercontent.com/4957057/234734837-9dfe988b-22a8-4962-b0da-e0fdba62255b.png)

Eevee:
![eevee](https://user-images.githubusercontent.com/4957057/234734854-6d7a210d-4278-43bd-a54f-00ae3c54b197.png)

Cycles:
![cycles](https://user-images.githubusercontent.com/4957057/234734869-e8351454-4c09-4ecd-b339-1a0c03c03391.png)

Prorender After this patch:
![ProrenderPostPatch](https://user-images.githubusercontent.com/4957057/234734902-0800a256-a4f7-4ede-ad95-c97cb9320838.png)

