### PR TITLE
RPRBLN-2281: Mac Mini M2 crash on addon deactivation

### DIFF
--- a/src/rprblender/nodes/__init__.py
+++ b/src/rprblender/nodes/__init__.py
@@ -143,28 +143,34 @@ def hide_cycles_and_eevee_poll(method):
 from . import sockets
 from . import rpr_nodes
 
-register_classes, unregister_classes = bpy.utils.register_classes_factory([
-    sockets.RPRSocketColorInterface,
+register_socket_classes, unregister_socket_classes = bpy.utils.register_classes_factory([
     sockets.RPRSocketColor,
-    sockets.RPRSocketFloatInterface,
     sockets.RPRSocketFloat,
-    sockets.RPRSocketWeightInterface,
     sockets.RPRSocketWeight,
-    sockets.RPRSocketWeightSoftInterface,
     sockets.RPRSocketWeightSoft,
-    sockets.RPRSocketMin1Max1Interface,
     sockets.RPRSocketMin1Max1,
-    sockets.RPRSocketLinkInterface,
     sockets.RPRSocketLink,
-    sockets.RPRSocketIORInterface,
     sockets.RPRSocketIOR,
-    sockets.RPRSocket_Float_Min0_SoftMax10Interface,
     sockets.RPRSocket_Float_Min0_SoftMax10,
-    sockets.RPRSocketAngle360Interface,
     sockets.RPRSocketAngle360,
-    sockets.RPRSocketValueInterface,
     sockets.RPRSocketValue,
+])
 
+
+register_socket_interface_classes, unregister_socket_interface_classes = bpy.utils.register_classes_factory([
+    sockets.RPRSocketColorInterface,
+    sockets.RPRSocketFloatInterface,
+    sockets.RPRSocketWeightInterface,
+    sockets.RPRSocketWeightSoftInterface,
+    sockets.RPRSocketMin1Max1Interface,
+    sockets.RPRSocketLinkInterface,
+    sockets.RPRSocketIORInterface,
+    sockets.RPRSocket_Float_Min0_SoftMax10Interface,
+    sockets.RPRSocketAngle360Interface,
+    sockets.RPRSocketValueInterface,
+])
+
+register_node_classes, unregister_node_classes = bpy.utils.register_classes_factory([
     rpr_nodes.RPRShaderNodeUber,
     rpr_nodes.RPRShaderNodeDiffuse,
     rpr_nodes.RPRShaderNodePassthrough,
@@ -195,7 +201,9 @@ def register():
     old_shader_node_category_poll = ShaderNodeCategory.poll
     ShaderNodeCategory.poll = hide_cycles_and_eevee_poll(ShaderNodeCategory.poll)
 
-    register_classes()
+    register_socket_interface_classes()
+    register_socket_classes()
+    register_node_classes()
     register_node_categories("RPR_NODES", node_categories)
 
 
@@ -203,4 +211,7 @@ def unregister():
     if old_shader_node_category_poll and ShaderNodeCategory.poll is not old_shader_node_category_poll:
         ShaderNodeCategory.poll = old_shader_node_category_poll
     unregister_node_categories("RPR_NODES")
-    unregister_classes()
+    unregister_node_classes()
+    # it's important to keep this order to avoid Blender crash on M2
+    unregister_socket_interface_classes()
+    unregister_socket_classes()


### PR DESCRIPTION
### PURPOSE
Mac Mini M2 crash on addon deactivation.
https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderBlenderAddon/issues/626

### EFFECT OF CHANGE
Fixed addon deactivation crash on Mac Mini M2.

### TECHNICAL STEPS
Put apart un/registration for node, socket, and socket interface classes and changed its order.
