### PR TITLE
RPRBLND-2290: deactivate hided denoiser options

### DIFF
--- a/src/rprblender/properties/view_layer.py
+++ b/src/rprblender/properties/view_layer.py
@@ -226,7 +226,7 @@ class RPR_DenoiserProperties(RPR_Properties):
     )
     def get_settings(self, scene, is_final_engine=True):
         return {
-            'enable': self.enable and self.is_available(scene, is_final_engine),
+            'enable': False,
             'filter_type': self.filter_type,
             'color_sigma': self.color_sigma,
             'normal_sigma': self.normal_sigma,


### PR DESCRIPTION
### PURPOSE
Need to deactivate old denoiser options, because this option was hidden in UI, but is still active and the user can't switch off or set up.

### EFFECT OF CHANGE
Denoiser doesn't affect the final render result in old scenes.

### TECHNICAL STEPS
Permanently deactivate denoiser "enable" property.

### NOTES FOR REVIEWERS
[Ticket](https://amdrender.atlassian.net/browse/RPRBLND-2291) to remove redundant 'denoiser' code.