### PR TITLE
Add RPR NormalMap node export for HybridPro

### DIFF
--- a/src/rprblender/nodes/rpr_nodes.py
+++ b/src/rprblender/nodes/rpr_nodes.py
@@ -1032,6 +1032,9 @@ class RPRShaderNodeNormalMap(RPRShaderNode):
         def export_hybrid(self):
             return self.get_input_normal('Map')
 
+        def export_hybridpro(self):
+            return self.export()
+
 
 class RPRShaderNodeEmissive(RPRShaderNode):
     """ Emissive node, only has a color and intensity """


### PR DESCRIPTION
### PURPOSE
Add RPR NormalMap node export for HybridPro

### EFFECT OF CHANGE
Added RPR NormalMap node export for HybridPro

### TECHNICAL STEPS
Added `export_hybridpro` for RPR NormalMap node