### PR TITLE
Updated latest Core 3.1.4

### DIFF
--- a/src/bindings/pyrpr/src/pyrprapi.py
+++ b/src/bindings/pyrpr/src/pyrprapi.py
@@ -683,7 +683,10 @@ if __name__=='__main__':
                  'rpr_format_ext',
                  'RPR_CONTEXT_CREATE_IMAGE_FROM_EXTERNAL_HANDLE',
                  'rprSetLogFunction',
-                 'RPR_GET_SUPPORTED_DEVICES_FUNC_NAME'
+                 'RPR_GET_SUPPORTED_DEVICES_FUNC_NAME',
+                 'rpr_debug_timings_mode',
+                 'RPR_CONTEXT_DEBUG_GET_CPU_TIMINGS',
+                 'RPR_CONTEXT_DEBUG_GET_GPU_TIMINGS'
                  ]
     )
 

--- a/src/rprblender/engine/preview_engine.py
+++ b/src/rprblender/engine/preview_engine.py
@@ -134,6 +134,7 @@ class PreviewEngine(Engine):
         self.rpr_context.set_parameter(pyrpr.CONTEXT_PREVIEW, True)
         settings_scene.rpr.export_ray_depth(self.rpr_context)
         settings_scene.rpr.export_pixel_filter(self.rpr_context)
+        settings_scene.rpr.export_compatibility_settings(self.rpr_context)
         self.rpr_context.texture_compression = settings_scene.rpr.texture_compression
 
         self.render_samples = settings_scene.rpr.viewport_limits.preview_samples

--- a/src/rprblender/engine/render_engine.py
+++ b/src/rprblender/engine/render_engine.py
@@ -771,6 +771,7 @@ class RenderEngine(Engine):
         self.rpr_context.set_parameter(pyrpr.CONTEXT_PREVIEW, False)
         scene.rpr.export_ray_depth(self.rpr_context)
         scene.rpr.export_pixel_filter(self.rpr_context)
+        scene.rpr.export_compatibility_settings(self.rpr_context)
         self.rpr_context.texture_compression = scene.rpr.texture_compression
 
         self.render_samples, self.render_time = (scene.rpr.limits.max_samples, scene.rpr.limits.seconds)

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -529,6 +529,8 @@ class ViewportEngine(Engine):
         scene.rpr.export_viewport_ray_depth(self.rpr_context)
         self.rpr_context.texture_compression = scene.rpr.texture_compression
         scene.rpr.export_pixel_filter(self.rpr_context)
+        scene.rpr.export_compatibility_settings(self.rpr_context)
+
 
         self.render_iterations, self.render_time = (viewport_limits.max_samples, 0)
 
@@ -1109,6 +1111,7 @@ class ViewportEngine(Engine):
         restart = scene.rpr.export_render_mode(self.rpr_context)
         restart |= scene.rpr.export_viewport_ray_depth(self.rpr_context)
         restart |= scene.rpr.export_pixel_filter(self.rpr_context)
+        restart |= scene.rpr.export_compatibility_settings(self.rpr_context)
 
         render_iterations, render_time = (scene.rpr.viewport_limits.max_samples, 0)
 

--- a/src/rprblender/engine/viewport_engine.py
+++ b/src/rprblender/engine/viewport_engine.py
@@ -531,7 +531,6 @@ class ViewportEngine(Engine):
         scene.rpr.export_pixel_filter(self.rpr_context)
         scene.rpr.export_compatibility_settings(self.rpr_context)
 
-
         self.render_iterations, self.render_time = (viewport_limits.max_samples, 0)
 
         self.is_finished = False

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -582,7 +582,7 @@ class RPR_RenderProperties(RPR_Properties):
         update=update_viewport_render_preset
     )
 
-    disable_normalize_light_intensity: BoolProperty(
+    legacy_toon_shader: BoolProperty(
         name="Use Legacy RPR Toon",
         description="Enable backward compatibility of RPR Toon shader appearance",
         default=False,
@@ -812,7 +812,7 @@ class RPR_RenderProperties(RPR_Properties):
         if self.final_render_mode != 'FULL2':
             return False
 
-        return rpr_context.set_parameter(pyrpr.CONTEXT_NORMALIZE_LIGHT_INTENSITY_ENABLED, not self.disable_normalize_light_intensity)
+        return rpr_context.set_parameter(pyrpr.CONTEXT_NORMALIZE_LIGHT_INTENSITY_ENABLED, not self.legacy_toon_shader)
 
     @classmethod
     def register(cls):

--- a/src/rprblender/properties/render.py
+++ b/src/rprblender/properties/render.py
@@ -582,6 +582,12 @@ class RPR_RenderProperties(RPR_Properties):
         update=update_viewport_render_preset
     )
 
+    disable_normalize_light_intensity: BoolProperty(
+        name="Use Legacy RPR Toon",
+        description="Enable backward compatibility of RPR Toon shader appearance",
+        default=False,
+    )
+
     hybrid_low_mem: BoolProperty(
         name="Use 4GB memory",
         description="Enable to support GPUs with 4Gb VRAM or less for Final render mode",
@@ -800,6 +806,13 @@ class RPR_RenderProperties(RPR_Properties):
 
         quality = getattr(pyrpr, 'RENDER_QUALITY_' + self.viewport_render_mode)
         return rpr_context.set_parameter(pyrpr.CONTEXT_RENDER_QUALITY, quality)
+
+    def export_compatibility_settings(self, rpr_context):
+        """ Exports backward compatibility settings """
+        if self.final_render_mode != 'FULL2':
+            return False
+
+        return rpr_context.set_parameter(pyrpr.CONTEXT_NORMALIZE_LIGHT_INTENSITY_ENABLED, not self.disable_normalize_light_intensity)
 
     @classmethod
     def register(cls):

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -239,8 +239,8 @@ class RPR_RENDER_PT_advanced(RPR_Panel):
             row.prop(limits, 'seed')
             row.prop(limits, 'anim_seed', text="", icon='TIME')
 
-            row = col.row()
-            row.prop(rpr, 'texture_compression')
+            col.prop(rpr, 'texture_compression')
+            col.prop(rpr, 'disable_normalize_light_intensity')
 
 
 class RPR_RENDER_PT_settings(RPR_Panel):

--- a/src/rprblender/ui/render.py
+++ b/src/rprblender/ui/render.py
@@ -240,7 +240,7 @@ class RPR_RENDER_PT_advanced(RPR_Panel):
             row.prop(limits, 'anim_seed', text="", icon='TIME')
 
             col.prop(rpr, 'texture_compression')
-            col.prop(rpr, 'disable_normalize_light_intensity')
+            col.prop(rpr, 'legacy_toon_shader')
 
 
 class RPR_RENDER_PT_settings(RPR_Panel):


### PR DESCRIPTION
### PURPOSE
Core submodules has to be updated.
Added support for `RPR Toon` backward compatibility `Render Properties tab -> Settings -> Final -> Use Legacy RPR Toon`.

![image](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderBlenderAddon/assets/42581166/38a99821-f22a-431c-97c3-6eccca5a1265)
![image](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderBlenderAddon/assets/42581166/4362b54b-cc0d-4149-8f39-1ee7eff814d7)


### TECHNICAL STEPS
Updated latest Core to 3.1.4.
Adjusted build script.
Added UI checkbox `Use Legacy RPR Toon` to support `RPR_CONTEXT_NORMALIZE_LIGHT_INTENSITY_ENABLED`
By default `Use Legacy RPR Toon = False -> RPR_CONTEXT_NORMALIZE_LIGHT_INTENSITY_ENABLED = 1`