### PR TITLE
Blender 4.1

### DIFF
--- a/BlenderPkg/build_linux.sh
+++ b/BlenderPkg/build_linux.sh
@@ -19,4 +19,4 @@ pushd ..
 ./build.sh
 popd
 
-python3.7 create_zip_addon.py
+python3.11 create_zip_addon.py

--- a/README-LNX.md
+++ b/README-LNX.md
@@ -38,7 +38,6 @@ python3.11 -m pip install numpy cffi imageio pytest
 ```
 echo "PATH=/home/amd/.local/bin:$PATH" >> ~/.bashrc
 ```
-13.  
 
 
 # Project build
@@ -68,4 +67,37 @@ export LD_LIBRARY_PATH=/usr/lib64
 python3.11 tests/commandline/run_blender.py $BLENDER_EXE tests/commandline/test_rpr.py
 // In the middle should be your path to Blender's executable file.
 ```
+
+# Debug with PyCharm in Linux
+1. Run pycharm, add project
+2. Add blender iterpretator. `Settings -> Python Iterpreter -> Add Iterpreter. Set blender python interpreter.
+For example, for blender 4.1 on my system:
+```
+/home/amd/blender-4.1.0-linux-x.64/4.1/python/bin/python3.11`
+```
+3. Run once script from project root:
+```
+./run_blender_with_rpr_Ubuntu.sh ~/blnddbg
+```
+4. Add Run/Debug configuration in Pycharm. 
+  1. Select Python from blender (see step 2)
+  2. Select script. Set script path to cmd_tools/run_blender.py. For example:
+    ```
+    /home/amd/workspace/RadeonProRenderBlenderAddon/cmd_tools/run_blender.py
+    ```
+  3. In script argument, set path to blender and path to AMDProRender main script:
+    ```
+    /home/amd/blender-4.1.0-linux-x64/blender /home/amd/workspace/RadeonProRenderBlenderAddon/cmd_tools/test_rpr.py
+    ```
+  3. In `Working directory` select path from step 3. For example:
+    ```
+    /home/amd/blnddbg
+    ```
+  4. In `Environment variables` set: 
+  ```
+  PYTHONUNBUFFERED=1;RPR_BLENDER_DEBUG=1
+  ```
+
+
+
 

--- a/README-LNX.md
+++ b/README-LNX.md
@@ -1,75 +1,71 @@
-### Addon Run/Use Linux Ubuntu Requirements
+# Development environment preparation
 
-- Ubuntu 18.04.03
+1. Ubuntu 22.04.04 LTS 
+2. Update system (required for update amdgpu linux drivers)
+```
+apt-get update
+apt-get upgrade
+```
+3. Download [amdgpu drivers for linux](https://www.amd.com/en/support/linux-drivers)
+4. Install amdgpu deb package (it setup official repo + required script for futher gpu driver install)
+```
+apt install ./amdgpu-install_*.deb
+```
+5. Install amdgpu driver itself
+```
+amdgpu-install
+```
+6. Reboot (required for amdgpu driver init)
+7. Download [blender 3.1](https://www.blender.org/download)
+8. Unpack somewhere
+9. Setup env. variable `BLENDER_EXE` and set to blender executable. For example:
+```
+echo "BLENDER_EXE=/home/feniks/bin/blender-4.1.0-linux-x64/blender" >> ~/.bashrc
+```
 
-- AMD drivers from web site
-    // The instruction is here: http://support.amd.com/en-us/kb-articles/Pages/AMDGPU-PRO-Install.aspx 
-
-- Blender 2.80 or later 
-    
-- Embree
-
-    sudo apt-get install alien dpkg
-
-    cd /tmp
-    wget https://github.com/embree/embree/releases/download/v2.12.0/embree-2.12.0.x86_64.rpm.tar.gz
-    tar xzvf ./embree-2.12.0.x86_64.rpm.tar.gz
-    sudo alien embree-lib-2.12.0-1.x86_64.rpm
-    sudo dpkg -i embree-lib_2.12.0-2_amd64.deb
-
-- OpenImageIO
-
-    sudo apt-get install libopenimageio1.6
-
-- FreeImage
-    sudo apt-get install libfreeimage-dev
-
-
-### ThirdParty libraries
-
-There is ThirdParty repository included to the project as a submodule. Please update submodules:
-
-Plugin includes 4 submodules:
-RadeonProRender SDK:
-git@github.com:Radeon-Pro/RadeonProRenderSDK.git
-
-Shared components
-Image Processing Library:
-git@github.com:Radeon-Pro/RadeonProImageProcessingSDK.git
-
-ThirdParty components and miscellaneous tools
-git@github.com:Radeon-Pro/RadeonProRenderThirdPartyComponents.git
-
-All of them are included via SSH protocol. You will need to create and install SSH keys https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh
-
-Once SSH keys are installed update/checkout submodules for active branch
-
-` git submodule update --init -f --recursive`
+10. Install blender build dependencies
+```
+sudo apt-get install castxml python3.11 python3.11-dev \
+	build-essential cmake \
+        makeself patchelf libpci-dev libdrm-dev opencl-headers \
+        libopenimageio-dev libfreeimage-dev libembree-dev
+```
+11. Install python deps
+```
+python3.11 -m pip install numpy cffi imageio pytest
+```
+12. Add to PATH required python binaries. For example:
+```
+echo "PATH=/home/amd/.local/bin:$PATH" >> ~/.bashrc
+```
+13.  
 
 
-### Build Requirements
+# Project build
 
-	sudo apt-get install  \
-		build-essential cmake python3-dev python3-pip \
-		makeself patchelf \
-		libpci-dev libdrm-dev opencl-headers
+> [!NOTE]
+> Dont forget to fetch project submodules  `git submodule update --init -f --recursive`
 
-	pip3 install numpy cffi imageio
+To build project run command
+```
+./build.sh
+```
 
-	// The pytest-v must be more then 3.0 it can be checked calling next command: pip3 show pytest
+## Create shipment archive
+To create shipment archive, please, run script:
+```
+cd BlenderPkg
+./build.sh
+```
+Shipment package should be in  `BuildPkg/.build` directory. 
 
+To install shipment build, run blender, select `Edit -> Preferences -> Addons -> Install`. 
+Then activate "RadeonProRender"
 
-### Build
-
-- Build the pyrpr and RPRHelper
-
-python3 build.py
-
-- run addon from source
+# Run addon from source
+```
 export LD_LIBRARY_PATH=/usr/lib64
-python3 tests/commandline/run_blender.py ~/blender/blender-2.78c-linux-glibc219-x86_64/blender tests/commandline/test_rpr.py
+python3.11 tests/commandline/run_blender.py $BLENDER_EXE tests/commandline/test_rpr.py
 // In the middle should be your path to Blender's executable file.
+```
 
-- make addon installer
-python3 build_zip_installer.py --target linux
-//this will make .zip that can be installed with Blender(User Preferences/Addons/InstallFromFile)

--- a/build.cmd
+++ b/build.cmd
@@ -64,14 +64,12 @@ if %vs_major%==15 or %vs_major%==16 (
 	goto :eof
 
 :build_plugin
-py -3.7 cmd_tools\create_sdk.py
-py -3.7 src\bindings\pyrpr\src\pyrprapi.py %castxml%
+py -3.11 cmd_tools\create_sdk.py
+py -3.11 src\bindings\pyrpr\src\pyrprapi.py %castxml%
 
 set bindingsOk=.\bindings-ok
 if exist %bindingsOk% (
-	py -3.7 build.py
-	py -3.9 build.py
-	py -3.10 build.py
+	py -3.11 build.py
 ) else (
 	echo Compiling bindings failed
 )

--- a/build.py
+++ b/build.py
@@ -41,7 +41,7 @@ subprocess.check_call([sys.executable, 'rpr.py'])
 subprocess.check_call([sys.executable, 'rpr_load_store.py'])
 os.chdir(cwd)
 
-if sys.version_info.major == 3 and sys.version_info.minor == 10:
+if sys.version_info.major == 3 and sys.version_info.minor == 11:
     # we are going to build RPRBlenderHelper only for python 3.10
     os.chdir('RPRBlenderHelper')
     shutil.rmtree('.build', ignore_errors=True)

--- a/build.py
+++ b/build.py
@@ -48,7 +48,7 @@ if sys.version_info.major == 3 and sys.version_info.minor == 11:
     os.makedirs('.build')
     os.chdir('.build')
     if 'Windows' == platform.system():
-        subprocess.check_call(['cmake', '-G', 'Visual Studio 16 2019',  '..'])
+        subprocess.check_call(['cmake', '-G', 'Visual Studio 17 2022',  '..'])
     else:
         subprocess.check_call(['cmake', '..'])
     subprocess.check_call(['cmake', '--build',  '.', '--config', 'Release', '--clean-first'])

--- a/build.py
+++ b/build.py
@@ -42,7 +42,7 @@ subprocess.check_call([sys.executable, 'rpr_load_store.py'])
 os.chdir(cwd)
 
 if sys.version_info.major == 3 and sys.version_info.minor == 11:
-    # we are going to build RPRBlenderHelper only for python 3.10
+    # we are going to build RPRBlenderHelper only for python 3.11
     os.chdir('RPRBlenderHelper')
     shutil.rmtree('.build', ignore_errors=True)
     os.makedirs('.build')

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,11 @@
+#!/bin/bash
+
 cxml="/usr/bin/castxml"
 if [ -f "$cxml" ]; then
-    python3.7 cmd_tools/create_sdk.py
-	python3.7 src/bindings/pyrpr/src/pyrprapi.py $cxml
+    python3.11 cmd_tools/create_sdk.py
+	python3.11 src/bindings/pyrpr/src/pyrprapi.py $cxml
 	if [ -f "./bindings-ok" ]; then
-		python3.7 build.py
-		python3.9 build.py
-		python3.10 build.py
+		python3.11 build.py
 	else
 		echo Compiling bindings failed
 	fi

--- a/run_blender_with_rpr_Ubuntu.sh
+++ b/run_blender_with_rpr_Ubuntu.sh
@@ -68,7 +68,7 @@ function main()
   export RPR_BLENDER_DEBUG=1
 	export LD_LIBRARY_PATH="$WORK_DIR:$LD_LIBRARY_PATH"
 
-	python3 cmd_tools/run_blender.py "$BLENDER_EXE" cmd_tools/test_rpr.py
+	python3.11 cmd_tools/run_blender.py "$BLENDER_EXE" cmd_tools/test_rpr.py
 
 }
 

--- a/run_blender_with_rpr_Ubuntu.sh
+++ b/run_blender_with_rpr_Ubuntu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #**********************************************************************
-# Copyright 2020 Advanced Micro Devices, Inc
+# Copyright 2024 Advanced Micro Devices, Inc
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,12 +20,8 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WORK_DIR=`mktemp -d -p /tmp rpr_blender_workdir_XXXXXXXX`
 
-RPR_SDK="ThirdParty/RadeonProRender SDK/Linux-Ubuntu"
-IMAGE_FILTER_DIR="ThirdParty/RadeonProImageProcessing/Linux/Ubuntu"
-IMAGE_FILTER_LIBNAME="libRadeonImageFilters64.so"
-GLTF_DIR="ThirdParty/RadeonProRender-GLTF/Linux-Ubuntu/lib"
-GLTF_LIBNAME="libProRenderGLTF.so"
-
+RPR_SDK="$DIR/RadeonProRenderSDK"
+RIF_SDK="$DIR/RadeonProImageProcessingSDK"
 
 function init()
 {
@@ -40,14 +36,13 @@ function init()
 	fi
 
 	# link rpr libs to workdir
-	for f in "$DIR/$RPR_SDK/lib/"*.so; do
-		ln -s "$f" "$WORK_DIR/"
-	done
-	# link imageprocessing lib to workdir
-	ln -s "$DIR/$IMAGE_FILTER_DIR/lib64/$IMAGE_FILTER_LIBNAME" "$WORK_DIR/"
+	find "$RPR_SDK/RadeonProRender/binUbuntu20" -name "*.so" -type f -exec ln -s {} "$WORK_DIR" \;
 
-	# link gltf lib to workdir
-	ln -s "$DIR/$GLTF_DIR/$GLTF_LIBNAME" "$WORK_DIR/"
+	# link hip kernels
+	ln -s $RPR_SDK/hipbin $WORK_DIR/hipbin
+
+	# link imageprocessing lib to workdir
+	find "$RIF_SDK/Ubuntu20/Dynamic" -name "*.so" -type f -exec ln -s {} "$WORK_DIR" \;
 
 	# link helper to workdir
 	ln -s "$DIR/RPRBlenderHelper/.build/libRPRBlenderHelper.so" "$WORK_DIR/"
@@ -65,7 +60,7 @@ function main()
 {
 	init
 
-  export RPR_BLENDER_DEBUG=1
+  	export RPR_BLENDER_DEBUG=1
 	export LD_LIBRARY_PATH="$WORK_DIR:$LD_LIBRARY_PATH"
 
 	python3.11 cmd_tools/run_blender.py "$BLENDER_EXE" cmd_tools/test_rpr.py

--- a/src/bindings/pyrpr/rpr.py
+++ b/src/bindings/pyrpr/rpr.py
@@ -95,11 +95,12 @@ def export(json_file_name, dependencies, header_file_name, cffi_name, output_nam
         if not cffi_libs_dir.is_dir():
             cffi_libs_dir = Path(_cffi_backend.__file__).parent / 'cffi.libs'
 
-        for path in cffi_libs_dir.iterdir():
-            if '.so' in path.suffixes:
-                # copy library needed for cffi backend
-                ffi_lib = str(path)
-                shutil.copy(ffi_lib, str(build_dir))
+        if cffi_libs_dir.is_dir():
+            for path in cffi_libs_dir.iterdir():
+                if '.so' in path.suffixes:
+                    # copy library needed for cffi backend
+                    ffi_lib = str(path)
+                    shutil.copy(ffi_lib, str(build_dir))
 
         # change RPATH for cffi backend to find libffi in the same directory
         cffi_backend_path = (Path(build_dir) / Path(_cffi_backend.__file__).name).absolute()

--- a/src/rprblender/export/mesh.py
+++ b/src/rprblender/export/mesh.py
@@ -57,14 +57,11 @@ class MeshData:
         uv_mesh = mesh
         if obj and obj.mode != 'OBJECT':
             mesh = obj.data
-        # Looks more like Blender's bug that we have to check that mesh has calc_normals_split().
-        # It is possible after deleting corresponded object with such mesh from the scene.
-        if not hasattr(mesh, 'calc_normals_split'):
-            log.warn("No calc_normals_split() in mesh", mesh)
-            return None
+
+        # replacement for calc_normals_split()
+        mesh.corner_normals
 
         # preparing mesh to export
-        mesh.calc_normals_split()
         mesh.calc_loop_triangles()
 
         # getting mesh export data
@@ -84,13 +81,10 @@ class MeshData:
         data.uvs = []
         data.uv_indices = []
 
-        if not hasattr(mesh, 'calc_normals_split'):
-            log.warn("No calc_normals_split() in mesh", mesh)
-            uv_mesh = mesh
+        uv_mesh = mesh
 
-        uv_mesh.calc_normals_split()
+        uv_mesh.corner_normals
         uv_mesh.calc_loop_triangles()
-
 
         primary_uv = uv_mesh.rpr.primary_uv_layer
         if primary_uv:
@@ -263,7 +257,7 @@ def assign_materials(rpr_context: RPRContext, rpr_shape: pyrpr.Shape, obj: bpy.t
             rpr_shape.set_volume_material(rpr_volume)
 
         # setting displacement material
-        if mat.cycles.displacement_method in {'DISPLACEMENT', 'BOTH'}:
+        if mat.displacement_method in {'DISPLACEMENT', 'BOTH'}:
             rpr_displacement = material.sync(rpr_context, mat, 'Displacement', obj=obj)
 
             # HybridPro: displacement disappears in case we set displacement material that is already set

--- a/src/rprblender/nodes/blender_nodes.py
+++ b/src/rprblender/nodes/blender_nodes.py
@@ -144,7 +144,7 @@ class ShaderNodeOutputMaterial(BaseNodeParser):
             this returns a bumped normal, else returns a node_lookup N """
 
         # TODO RPRContextHybridPro doesn't support MATERIAL_NODE_BUMP_MAP
-        if self.material.cycles.displacement_method in {"BUMP", "BOTH"} and \
+        if self.material.displacement_method in {"BUMP", "BOTH"} and \
                 not isinstance(self.rpr_context, RPRContextHybridPro):
             displacement_input = self.get_input_link("Displacement")
             if displacement_input:


### PR DESCRIPTION
### PURPOSE
Add support for blender 4.1

### EFFECT OF CHANGE
User are able to install plugin on blender 4.1

### TECHNICAL STEPS
Use blender new API in mesh.py
Switch to python 3.11 (blender switched to python 3.11)
Fix linux/windows build scripts
Update linux readme

### KNOWN ISSUES
* Linux build doesn't work (yet) due to issue in rpr shaders
* Windows: plugin doesn't initialize on systems with APU's and GPU (read - on some laptops). Unsupported GPU make's plugin "stuck" in initialization.
* Windows: Pre-RDNA gpu's doesn't work
